### PR TITLE
adding google social provider

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,8 @@ from .routes.main import main
 from .routes.trips import trips
 from .routes.payments import payments
 from .routes.admin import admin
+from .routes.auth import auth
+from .auth import init_oauth
 from .models import db
 import os
 
@@ -12,9 +14,11 @@ def create_app(environment=None):
         environment = os.getenv('FLASK_ENV', 'development')
     
     app = Flask(__name__, static_folder='static', static_url_path='/static')
+    app.secret_key = os.getenv('FLASK_SECRET_KEY')  # Required for sessions
     
     load_stripe_config()
     configure_database(app, environment)
+    init_oauth(app)
     
     db.init_app(app)
     
@@ -22,6 +26,7 @@ def create_app(environment=None):
     app.register_blueprint(trips)
     app.register_blueprint(payments)
     app.register_blueprint(admin)
+    app.register_blueprint(auth)
     
     with app.app_context():
         db.create_all()

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,50 @@
+from functools import wraps
+from flask import redirect, url_for, session, flash, current_app, request
+from authlib.integrations.flask_client import OAuth
+from authlib.integrations.base_client.errors import OAuthError
+import os
+from urllib.parse import urlencode
+
+oauth = OAuth()
+
+def init_oauth(app):
+    """Initialize OAuth with Google configuration"""
+    oauth.init_app(app)
+    
+    # Configure Google OAuth
+    oauth.register(
+        name='google',
+        server_metadata_url='https://accounts.google.com/.well-known/openid-configuration',
+        client_id=os.getenv('GOOGLE_CLIENT_ID'),
+        client_secret=os.getenv('GOOGLE_CLIENT_SECRET'),
+        client_kwargs={
+            'scope': 'openid email profile',
+            'prompt': 'select_account'  # Forces account selection each time
+        }
+    )
+
+def is_allowed_domain(email):
+    """Check if email domain is allowed"""
+    return email and email.endswith('@twincitiesskiclub.org')
+
+def admin_required(f):
+    """Decorator to protect admin routes"""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if 'user' not in session:
+            return redirect(url_for('auth.login', next=request.url))
+        
+        if not is_allowed_domain(session['user'].get('email')):
+            flash('Access restricted to @twincitieskiclub.org domain', 'error')
+            return redirect(url_for('main.get_home_page'))
+            
+        return f(*args, **kwargs)
+    return decorated_function
+
+def handle_oauth_error(error):
+    """Handle OAuth errors and return appropriate response"""
+    error_msg = str(error)
+    if isinstance(error, OAuthError):
+        error_msg = "Authentication failed. Please try again."
+    flash(error_msg, 'error')
+    return redirect(url_for('main.get_home_page'))

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,12 +1,11 @@
 from flask import Blueprint, render_template, jsonify, request
-import json
-import stripe
-import os
+from ..auth import admin_required
 from ..models import db, Payment
 
 admin = Blueprint('admin', __name__)
 
 @admin.route('/admin')
+@admin_required
 def get_admin_page():
     payments = Payment.query.all()
     return render_template('admin.html', payments=payments)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,39 @@
+from flask import Blueprint, redirect, url_for, session, flash, current_app, request
+from ..auth import oauth, admin_required
+
+auth = Blueprint('auth', __name__)
+
+@auth.route('/login')
+def login():
+    session['next_url'] = request.args.get('next') or url_for('admin.get_admin_page')
+    redirect_uri = url_for('auth.authorize', _external=True)
+    return oauth.google.authorize_redirect(redirect_uri)
+
+@auth.route('/authorize')
+def authorize():
+    try:
+        token = oauth.google.authorize_access_token()
+        user_info = token.get('userinfo')
+        if user_info:
+            session['user'] = {
+                'email': user_info['email'],
+                'name': user_info['name']
+            }
+            if not user_info['email'].endswith('@twincitiesskiclub.org'):
+                flash('Unauthorized domain. Access restricted to @twincitiesskiclub.org', 'error')
+                return redirect(url_for('main.get_home_page'))
+                
+            flash('Successfully logged in!', 'success')
+            next_url = session.pop('next_url', url_for('admin.get_admin_page'))
+            return redirect(next_url)
+    except Exception as e:
+        flash(f'Authentication failed: {str(e)}', 'error')
+        
+    return redirect(url_for('main.get_home_page'))
+
+@auth.route('/logout')
+def logout():
+    session.pop('user', None)
+    session.pop('next_url', None)
+    flash('Successfully logged out', 'success')
+    return redirect(url_for('main.get_home_page'))

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -11,6 +11,23 @@
   </head>
   <body>
     <div class="admin-container">
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="flash-message {{ category }}">
+              {{ message }}
+            </div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+
+      {% if session.user %}
+        <div class="user-info">
+          Logged in as: {{ session.user.email }}
+          <a href="{{ url_for('auth.logout') }}">Logout</a>
+        </div>
+      {% endif %}
+
       <h1>Payments Overview</h1>
       <table>
         <thead>
@@ -34,7 +51,6 @@
             <td>{{ payment.payment_intent_id }}</td>
             <td>{{ payment.email }}</td>
             <td>{{ payment.name }}</td>
-            <td>{{ payment.amount }}</td>
             <td>{{ payment.status }}</td>
             <td>{{ payment.trip_id }}</td>
             <td>{{ payment.created_at }}</td>

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ urllib3==2.2.3
 Werkzeug==3.1.2
 gunicorn==23.0.0
 Flask-SQLAlchemy==3.1.1
+Authlib==1.3.2
+google-auth==2.36.0


### PR DESCRIPTION
Add Google OAuth authentication for admin routes

---

### Description

**What does this PR do?**
- Implements Google OAuth authentication for admin routes
- Restricts admin access to users with @twincitiesskiclub.org email domains
- Adds login/logout functionality with session management
- Secures admin routes with a new `@admin_required` decorator

**Why are these changes necessary?**
- To secure administrative functions and ensure only authorized club members can access sensitive data
- Provides a secure and standardized authentication method using Google OAuth
- Prevents unauthorized access to admin features

---

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe):

---

### Testing

**How has this been tested?**
- Verified OAuth flow with Google authentication
- Tested login/logout functionality
- Confirmed domain restriction works for @twincitiesskiclub.org emails
- Validated session management and secure route protection
- Tested error handling for unauthorized access attempts

---

### Screenshots (if applicable)

N/A

---

### Additional Comments

- Requires new environment variables:
  - FLASK_SECRET_KEY
  - GOOGLE_CLIENT_ID
  - GOOGLE_CLIENT_SECRET
- Added new dependencies: Authlib and google-auth
- Updates admin template to show login status and flash messages