### PR TITLE
Add CSV export for season members

### DIFF
--- a/app/templates/admin/seasons.html
+++ b/app/templates/admin/seasons.html
@@ -80,7 +80,8 @@
             <td>
               <div class="action-buttons">
                 <a href="{{ url_for('admin.edit_season', season_id=season.id) }}" class="button button-small">Edit</a>
-                <button 
+                <a href="{{ url_for('admin.export_season_members', season_id=season.id) }}" class="button button-small">Export</a>
+                <button
                   class="button button-small button-danger"
                   onclick="confirmDelete('{{ season.id }}', '{{ season.name }}')"
                 >


### PR DESCRIPTION
## Summary
- add admin route to export season members as CSV
- add Export button for each season in admin view

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f673d4668832690c766e7246bc661