### PR TITLE
Add Dryland Triathlon info page

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -40,3 +40,7 @@ def get_home_page():
                            season=season, 
                            now=now_utc, # Pass UTC time for template date comparisons
                            is_season_registration_open=is_season_registration_open)
+
+@main.route('/tri')
+def dryland_triathlon_page():
+    return render_template('dryland-triathlon.html')

--- a/app/static/css/styles/components/_triathlon.css
+++ b/app/static/css/styles/components/_triathlon.css
@@ -1,0 +1,40 @@
+/*----------  Dryland Triathlon Page  ----------*/
+.triathlon-hero {
+    text-align: center;
+    padding: 32px 16px;
+    background: linear-gradient(135deg, var(--s), #e0f7ea);
+    border-radius: var(--r);
+    margin-bottom: 24px;
+}
+
+.triathlon-hero h2 {
+    margin: 0 0 8px;
+    font-size: 28px;
+    color: var(--p);
+}
+
+.triathlon-hero p {
+    margin: 0;
+    color: var(--g-d);
+    font-size: 16px;
+}
+
+.triathlon-section {
+    margin-bottom: 24px;
+}
+
+.triathlon-section h3 {
+    margin-bottom: 8px;
+    color: var(--p);
+}
+
+.triathlon-list {
+    padding-left: 20px;
+    margin: 0;
+}
+
+.triathlon-list li {
+    margin-bottom: 8px;
+    color: var(--g-m);
+    font-size: 16px;
+}

--- a/app/static/css/styles/main.css
+++ b/app/static/css/styles/main.css
@@ -5,6 +5,7 @@
 @import 'components/_trips.css';
 @import 'components/_forms.css';
 @import 'components/_buttons.css';
+@import 'components/_triathlon.css';
 @import 'states/_states.css';
 @import 'animations/_animations.css';
 @import 'utils/_media-queries.css';

--- a/app/templates/dryland-triathlon.html
+++ b/app/templates/dryland-triathlon.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>TCSC Dryland Triathlon</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/normalize.css') }}" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles/main.css') }}" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+  </head>
+  <body>
+    <div class="sr-root">
+      <div class="sr-main">
+        <header class="sr-header">
+          <div class="sr-header__logo">
+            <img src="{{ url_for('static', filename='images/tcsc-logo.svg') }}" alt="TCSC Logo">
+          </div>
+          <h1 class="sr-header__title">Dryland Triathlon</h1>
+        </header>
+        <div class="triathlon-hero">
+          <h2>Roll. Ride. Run.</h2>
+          <p>Saturday, October 25th, 2025 – Carver Park Reserve, Parley Lake Area</p>
+        </div>
+        <section class="triathlon-section">
+          <h3>About the Event</h3>
+          <p>Join us for TCSC's pilot year of the Dryland Triathlon! This fun event combines three common off-season activities for Nordic skiers: rollerskiing, mountain biking, and trail running. Show off your off-season gains before winter arrives!</p>
+          <p>Compete individually or with two teammates. Each leg starts and ends in the Parley Lake lot where your team will have a designated transition zone.</p>
+        </section>
+        <section class="triathlon-section">
+          <h3>Distances &amp; Schedule</h3>
+          <ul class="triathlon-list">
+            <li>Long course: 18K roll, 17K ride, 11K run – starts at 9:00&nbsp;AM</li>
+            <li>Short course: 9.5K roll, 9K ride, 6K run – starts at 9:30&nbsp;AM</li>
+          </ul>
+        </section>
+        <section class="triathlon-section">
+          <h3>Equipment Rules</h3>
+          <ul class="triathlon-list">
+            <li><strong>Roll:</strong> Fastest wheels allowed are #2 or Marwe #6. Freestyle technique only.</li>
+            <li><strong>Ride:</strong> No e-bikes. Rigid, hardtail, or full-suspension mountain bikes are welcome.</li>
+            <li>Helmets required for all legs.</li>
+          </ul>
+        </section>
+        <section class="triathlon-section">
+          <h3>Registration</h3>
+          <p>Registration opens July 25th, 2025 and is limited to 100 total participants or teams (50 short course, 50 long course). Pricing will be announced soon.</p>
+        </section>
+        <section class="triathlon-section">
+          <h3>About TCSC</h3>
+          <p>The Twin Cities Ski Club (TCSC) is a welcoming community of Nordic skiers offering training, trips, and fun events for skiers of all abilities. Come meet fellow skiers and join the community!</p>
+        </section>
+        <div style="margin-top: 1.5em;">
+          <a href="/" class="trip-button">&larr; Back to Home</a>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create a static page for the Dryland Triathlon
- style the page with new triathlon CSS
- add CSS import to main stylesheet
- add route for the info page
- change route path to `/tri`

## Testing
- `flake8 app/routes/main.py` *(fails: many existing style violations)*
- `python -m compileall -q app`


------
https://chatgpt.com/codex/tasks/task_e_6881d138309c83269f066927146416f2