### PR TITLE
Fix season display to show most recent season instead of oldest

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -18,13 +18,13 @@ def get_home_page():
         Trip.signup_end > now_utc # Use UTC for DB query
     ).order_by(Trip.start_date).all()
 
-    # Fetch the current or next season by registration window or start date
+    # Fetch the most recent season by registration window or start date
     season = (
         Season.query
         .filter(
             (Season.returning_start != None) | (Season.new_start != None)
         )
-        .order_by(Season.start_date.asc())
+        .order_by(Season.start_date.desc())
         .first()
     )
     


### PR DESCRIPTION
Changed ordering from start_date ASC to DESC so the main page displays the most recent season rather than potentially showing old seasons.

🤖 Generated with [Claude Code](https://claude.ai/code)