### PR TITLE
Fix double Stripe initialization on season registration page

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -236,8 +236,8 @@ class PaymentForm {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  // Initialize PaymentForm for trip registration pages (with .sr-payment-form)
-  if (document.querySelector('.sr-payment-form')) {
+  // Initialize PaymentForm for trip registration pages (with .sr-payment-form but NOT registration forms)
+  if (document.querySelector('.sr-payment-form') && !document.getElementById('registration-form')) {
     new PaymentForm();
   }
 


### PR DESCRIPTION
The season registration form was getting initialized twice - once by the PaymentForm class and once by the dedicated season registration code. This caused the "Failed to initialize payment form" error. Added a check to exclude registration forms from PaymentForm initialization.

🤖 Generated with [Claude Code](https://claude.ai/code)