### PR TITLE
Fix returning member recognition and UserSeason status case issues

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -115,7 +115,11 @@ class User(db.Model):
 
     @property
     def is_returning(self):
-        return any(us.status == 'ACTIVE' for us in self.user_seasons)
+        # A user is returning if they have been ACTIVE in any past season
+        # This includes users who were "new" but made it through the lottery
+        # Excludes PENDING_LOTTERY and DROPPED users who never made it through
+        # Check both uppercase and lowercase for compatibility with existing data
+        return any(us.status in ('ACTIVE', 'active') for us in self.user_seasons)
 
     __table_args__ = (
         db.CheckConstraint(

--- a/app/routes/payments.py
+++ b/app/routes/payments.py
@@ -95,7 +95,7 @@ def webhook_received():
                         season_id=season_id,
                         registration_type=member_type,
                         registration_date=datetime.utcnow().date(),
-                        status='pending_lottery'
+                        status='PENDING_LOTTERY'
                     )
                     db.session.add(user_season)
                     db.session.commit()
@@ -109,7 +109,7 @@ def webhook_received():
             if user:
                 user_season = UserSeason.query.filter_by(user_id=user.id, season_id=season_id).first()
                 if user_season:
-                    user_season.status = 'active'
+                    user_season.status = 'ACTIVE'
                     user_season.payment_date = datetime.utcnow().date()
                     user.status = 'active'
                     db.session.commit()


### PR DESCRIPTION
- Fixed UserSeason status values to use uppercase (ACTIVE, PENDING_LOTTERY) consistently
- Made is_returning check case-insensitive to handle existing lowercase data
- Users who were "new" but made it through lottery (status=ACTIVE) are now properly recognized as returning members

This fixes the issue where users like Joe Harrington who successfully joined as new members weren't being recognized as returning members for future seasons.

🤖 Generated with [Claude Code](https://claude.ai/code)