### PR TITLE
Fix radio button and checkbox layout in forms

### DIFF
--- a/app/static/css/styles/components/_admin.css
+++ b/app/static/css/styles/components/_admin.css
@@ -103,7 +103,7 @@
   font-weight: 500;
 }
 
-.form-group input,
+.form-group input:not([type="radio"]):not([type="checkbox"]),
 .form-group select,
 .form-group textarea {
   width: 100%;


### PR DESCRIPTION
## Summary
- Fixed radio buttons and checkboxes that were displaying with text on separate lines
- Modified CSS selector to exclude radio/checkbox inputs from 100% width rule

## Problem
The `.form-group input` selector in `_admin.css` was applying `width: 100%` to ALL input elements, including radio buttons and checkboxes. This caused the input to take full width, pushing the label text to the next line.

## Solution
Changed the selector to `.form-group input:not([type="radio"]):not([type="checkbox"])` to exclude radio buttons and checkboxes from the full-width styling, allowing them to maintain their natural size and keep labels inline.

## Test plan
- [ ] View the season registration form at `/seasons/<id>/register`
- [ ] Verify radio buttons for "Preferred Technique" display inline with their labels
- [ ] Verify radio buttons for "Ski Experience" display inline with their labels
- [ ] Verify checkboxes display inline with their labels
- [ ] Verify other form inputs (text, email, etc.) still display full width

🤖 Generated with [Claude Code](https://claude.ai/code)