### PR TITLE
Add registration deadline to triathlon page

### DIFF
--- a/app/static/css/styles/components/_triathlon.css
+++ b/app/static/css/styles/components/_triathlon.css
@@ -190,6 +190,15 @@
     color: var(--s-d);
     font-size: 14px;
     font-style: italic;
+    margin-bottom: 8px;
+}
+
+.triathlon-deadline {
+    text-align: center;
+    color: var(--p);
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0;
 }
 
 /* Enhanced Link Styling */

--- a/app/templates/dryland-triathlon.html
+++ b/app/templates/dryland-triathlon.html
@@ -59,6 +59,7 @@
             </a>
           </div>
           <p class="triathlon-discount-note">TCSC members receive a discount</p>
+          <p class="triathlon-deadline">Registration closes September 14th at 11:59 PM</p>
         </section>
         <section class="triathlon-section">
           <h3>Team Finder</h3>


### PR DESCRIPTION
## Summary
Added the registration closing date to the triathlon page for clarity.

## Changes
- Added "Registration closes September 14th at 11:59 PM" below the pricing information
- Styled the deadline text to stand out with navy color and bold weight

## Screenshot
The deadline now appears prominently in the registration section below the member discount note.

🤖 Generated with [Claude Code](https://claude.ai/code)