### PR TITLE
Add North Shore route handler

### DIFF
--- a/app/routes/trips.py
+++ b/app/routes/trips.py
@@ -32,3 +32,8 @@ def get_cuyuna_page():
 def get_great_bear_chase_page():
     trip = Trip.query.filter_by(slug='great-bear-chase').first_or_404()
     return render_template('trips/great-bear-chase.html', trip=trip)
+
+@trips.route('/north-shore')
+def get_north_shore_page():
+    trip = Trip.query.filter_by(slug='north-shore').first_or_404()
+    return render_template('trips/north-shore.html', trip=trip)


### PR DESCRIPTION
## Summary
- Added the missing route handler for the North Shore trip page
- Fixes issue where `/north-shore` was not accessible even though the template was added

## Changes
- Added route handler in `app/routes/trips.py` for `/north-shore` endpoint
- Handler loads the trip from database using slug 'north-shore' and renders the template

## Context
The HTML template for North Shore was already added in PR #65, but the route handler was missing, preventing the page from being accessible.

🤖 Generated with [Claude Code](https://claude.ai/code)