### PR TITLE
Add zero-downtime deployment configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn "app:create_app()"
+web: gunicorn "app:create_app()" --workers 2 --graceful-timeout 30 --preload

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,5 +1,5 @@
-from flask import Blueprint, render_template
-from ..models import Trip, Season
+from flask import Blueprint, render_template, jsonify
+from ..models import db, Trip, Season
 from datetime import datetime
 import pytz
 
@@ -44,3 +44,12 @@ def get_home_page():
 @main.route('/tri')
 def dryland_triathlon_page():
     return render_template('dryland-triathlon.html')
+
+@main.route('/health')
+def health_check():
+    try:
+        # Check database connectivity
+        db.session.execute('SELECT 1')
+        return jsonify({'status': 'healthy'}), 200
+    except Exception as e:
+        return jsonify({'status': 'unhealthy', 'error': str(e)}), 503


### PR DESCRIPTION
## Summary
- Fixes the 502 Bad Gateway error during Render deployments
- Ensures website remains available when deploying new versions

## Changes
1. **Added health check endpoint** (`/health`):
   - Checks database connectivity
   - Returns JSON status for Render monitoring
   
2. **Updated Gunicorn configuration**:
   - Set 2 workers for simple redundancy
   - Added 30-second graceful timeout for clean shutdowns
   - Added `--preload` flag to reduce memory and speed up worker restarts

## Render GUI Configuration Required
After merging, update these settings in Render dashboard:
1. **Health Check Path**: Change from `/healthz` to `/health`
2. **Start Command**: Copy from the updated Procfile

This ensures zero-downtime deployments with minimal complexity.

🤖 Generated with [Claude Code](https://claude.ai/code)