### PR TITLE
Add 50KUM trip route and template

### DIFF
--- a/app/routes/trips.py
+++ b/app/routes/trips.py
@@ -37,3 +37,8 @@ def get_great_bear_chase_page():
 def get_north_shore_page():
     trip = Trip.query.filter_by(slug='north-shore').first_or_404()
     return render_template('trips/north-shore.html', trip=trip)
+
+@trips.route('/50kum')
+def get_50kum_page():
+    trip = Trip.query.filter_by(slug='50kum').first_or_404()
+    return render_template('trips/50kum.html', trip=trip)

--- a/app/templates/trips/50kum.html
+++ b/app/templates/trips/50kum.html
@@ -1,0 +1,4 @@
+{% extends "trips/base_trip.html" %}
+
+{% block title %}TCSC 50KUM Registration{% endblock %}
+{% block meta_description %}TCSC 50KUM Registration and Payment{% endblock %}


### PR DESCRIPTION
## Summary
- add a dedicated trip template for the 50KUM event
- register the `/50kum` route to render the new template using the `50kum` slug

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8d79687e88326baafeff559a133e8