### PR TITLE
Remove zero-downtime deployment configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn "app:create_app()" --workers 2 --graceful-timeout 30 --preload
+web: gunicorn "app:create_app()"

--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -1,5 +1,5 @@
-from flask import Blueprint, render_template, jsonify
-from ..models import db, Trip, Season
+from flask import Blueprint, render_template
+from ..models import Trip, Season
 from datetime import datetime
 import pytz
 
@@ -45,11 +45,3 @@ def get_home_page():
 def dryland_triathlon_page():
     return render_template('dryland-triathlon.html')
 
-@main.route('/health')
-def health_check():
-    try:
-        # Check database connectivity
-        db.session.execute('SELECT 1')
-        return jsonify({'status': 'healthy'}), 200
-    except Exception as e:
-        return jsonify({'status': 'unhealthy', 'error': str(e)}), 503


### PR DESCRIPTION
## Summary
- remove the Render health check route and related database import that were added for the zero-downtime deployment attempt
- restore the Procfile to the original Gunicorn command without the extra worker and preload settings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb16c57a548326b168f8d57eb2a1d1