### PR TITLE
Remove outdated Dry Tri registration deadline note

### DIFF
--- a/app/templates/dryland-triathlon.html
+++ b/app/templates/dryland-triathlon.html
@@ -59,7 +59,6 @@
             </a>
           </div>
           <p class="triathlon-discount-note">TCSC members receive a discount</p>
-          <p class="triathlon-deadline">Registration closes September 14th at 11:59 PM</p>
         </section>
         <section class="triathlon-section">
           <h3>Team Finder</h3>


### PR DESCRIPTION
## Summary
- remove the outdated note about Dry Tri registration closing on September 14

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1743e20d48326a9c8840b1c13c614