### PR TITLE
feat: add Waitlist filter to admin users page

### DIFF
--- a/app/static/admin_users.js
+++ b/app/static/admin_users.js
@@ -237,6 +237,8 @@ function applyGlobalView() {
         title = `${season ? season.name : 'Season'} Members`;
     } else if (currentView === 'alumni') {
         title = 'Alumni Members';
+    } else if (currentView === 'waitlist') {
+        title = 'Waitlist Members';
     } else {
         title = 'All Members';
     }
@@ -303,6 +305,13 @@ function applyFilters() {
         // Global view filter
         if (currentView === 'alumni') {
             if (data.status !== 'ALUMNI') {
+                return false;
+            }
+        } else if (currentView === 'waitlist') {
+            const statuses = Object.values(data.seasons || {});
+            const hasLotteryStatus = statuses.some(s => s === 'PENDING_LOTTERY' || s === 'DROPPED_LOTTERY');
+            const hasBeenActive = statuses.some(s => s === 'ACTIVE');
+            if (!hasLotteryStatus || hasBeenActive) {
                 return false;
             }
         } else if (currentView === 'current' && currentSeason) {

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -353,6 +353,7 @@
             <button class="admin-pill active" data-view="all">All</button>
             <button class="admin-pill" data-view="current">Current</button>
             <button class="admin-pill" data-view="alumni">Alumni</button>
+            <button class="admin-pill" data-view="waitlist">Waitlist</button>
         </div>
         <!-- Filters -->
         <select id="global-season-select" class="admin-select">

--- a/docs/superpowers/plans/2026-04-20-waitlist-filter.md
+++ b/docs/superpowers/plans/2026-04-20-waitlist-filter.md
@@ -1,0 +1,175 @@
+# Waitlist Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Waitlist" pill to the admin users view switcher that filters to users who registered for the lottery but never became active members.
+
+**Architecture:** Pure client-side filtering. The existing `/admin/users/data` endpoint already returns each user's `seasons` dict with statuses for all seasons. No backend changes needed.
+
+**Tech Stack:** HTML (Jinja2 template), vanilla JavaScript, Tabulator.js
+
+---
+
+### Task 1: Add Waitlist pill button to HTML template
+
+**Files:**
+- Modify: `app/templates/admin/users.html:352-356`
+
+- [ ] **Step 1: Add the Waitlist pill button**
+
+In `app/templates/admin/users.html`, find the pill group (line 352-356):
+
+```html
+<div class="admin-pill-group">
+    <button class="admin-pill active" data-view="all">All</button>
+    <button class="admin-pill" data-view="current">Current</button>
+    <button class="admin-pill" data-view="alumni">Alumni</button>
+</div>
+```
+
+Replace with:
+
+```html
+<div class="admin-pill-group">
+    <button class="admin-pill active" data-view="all">All</button>
+    <button class="admin-pill" data-view="current">Current</button>
+    <button class="admin-pill" data-view="alumni">Alumni</button>
+    <button class="admin-pill" data-view="waitlist">Waitlist</button>
+</div>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/templates/admin/users.html
+git commit -m "feat: add Waitlist pill button to admin users toolbar"
+```
+
+---
+
+### Task 2: Add waitlist filtering logic to JavaScript
+
+**Files:**
+- Modify: `app/static/admin_users.js:227-242` (applyGlobalView title logic)
+- Modify: `app/static/admin_users.js:296-318` (applyFilters view filter logic)
+
+- [ ] **Step 1: Add waitlist title in `applyGlobalView`**
+
+In `app/static/admin_users.js`, find the title logic in `applyGlobalView()` (lines 230-242):
+
+```javascript
+    let seasonIdToUse = selectedSeasonId;
+    let title = 'All Members';
+
+    if (currentView === 'current' && currentSeason) {
+        seasonIdToUse = currentSeason.id;
+        title = `${currentSeason.name} Members`;
+    } else if (currentView === 'season' && selectedSeasonId) {
+        const season = allSeasons.find(s => s.id === selectedSeasonId);
+        title = `${season ? season.name : 'Season'} Members`;
+    } else if (currentView === 'alumni') {
+        title = 'Alumni Members';
+    } else {
+        title = 'All Members';
+    }
+```
+
+Replace with:
+
+```javascript
+    let seasonIdToUse = selectedSeasonId;
+    let title = 'All Members';
+
+    if (currentView === 'current' && currentSeason) {
+        seasonIdToUse = currentSeason.id;
+        title = `${currentSeason.name} Members`;
+    } else if (currentView === 'season' && selectedSeasonId) {
+        const season = allSeasons.find(s => s.id === selectedSeasonId);
+        title = `${season ? season.name : 'Season'} Members`;
+    } else if (currentView === 'alumni') {
+        title = 'Alumni Members';
+    } else if (currentView === 'waitlist') {
+        title = 'Waitlist Members';
+    } else {
+        title = 'All Members';
+    }
+```
+
+- [ ] **Step 2: Add waitlist filter logic in `applyFilters`**
+
+In the same file, find the view filter section inside `applyFilters()` (lines 303-318):
+
+```javascript
+        // Global view filter
+        if (currentView === 'alumni') {
+            if (data.status !== 'ALUMNI') {
+                return false;
+            }
+        } else if (currentView === 'current' && currentSeason) {
+            // Only show members registered for current season
+            if (!data.seasons || !data.seasons[currentSeason.id]) {
+                return false;
+            }
+        } else if (currentView === 'season' && selectedSeasonId) {
+            // Only show members registered for selected season
+            if (!data.seasons || !data.seasons[selectedSeasonId]) {
+                return false;
+            }
+        }
+```
+
+Replace with:
+
+```javascript
+        // Global view filter
+        if (currentView === 'alumni') {
+            if (data.status !== 'ALUMNI') {
+                return false;
+            }
+        } else if (currentView === 'waitlist') {
+            const statuses = Object.values(data.seasons || {});
+            const hasLotteryStatus = statuses.some(s => s === 'PENDING_LOTTERY' || s === 'DROPPED_LOTTERY');
+            const hasBeenActive = statuses.some(s => s === 'ACTIVE');
+            if (!hasLotteryStatus || hasBeenActive) {
+                return false;
+            }
+        } else if (currentView === 'current' && currentSeason) {
+            // Only show members registered for current season
+            if (!data.seasons || !data.seasons[currentSeason.id]) {
+                return false;
+            }
+        } else if (currentView === 'season' && selectedSeasonId) {
+            // Only show members registered for selected season
+            if (!data.seasons || !data.seasons[selectedSeasonId]) {
+                return false;
+            }
+        }
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/static/admin_users.js
+git commit -m "feat: add waitlist view filtering logic"
+```
+
+---
+
+### Task 3: Manual verification
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+./scripts/dev.sh
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Navigate to `https://tcsc.ski/admin/users` (or localhost equivalent) and verify:
+
+1. The "Waitlist" pill appears in the toolbar after "Alumni"
+2. Clicking "Waitlist" filters the grid and shows "Waitlist Members" title
+3. The member count updates correctly
+4. Clicking other pills ("All", "Current", "Alumni") still works correctly
+5. The season dropdown still works (deselects pills, shows season view)
+6. Other filters (search, status, roles, season status) still compose correctly when in waitlist view

--- a/docs/superpowers/specs/2026-04-20-waitlist-filter-design.md
+++ b/docs/superpowers/specs/2026-04-20-waitlist-filter-design.md
@@ -1,0 +1,62 @@
+# Waitlist Filter — Admin Users Page
+
+## Summary
+
+Add a "Waitlist" view pill to the admin users page (`/admin/users`) view switcher, alongside the existing "All | Current | Alumni" pills. This lets admins quickly see members who tried to register but never got in.
+
+## Waitlist Definition
+
+A user is on the waitlist if:
+- They have `PENDING_LOTTERY` or `DROPPED_LOTTERY` status in **any** season
+- AND they have **never** had `ACTIVE` status in any season
+
+This captures people who expressed interest (registered for the lottery) but were never accepted as members.
+
+## UI
+
+The view switcher row changes from:
+
+```
+[ All ] [ Current ] [ Alumni ]
+```
+
+to:
+
+```
+[ All ] [ Current ] [ Alumni ] [ Waitlist ]
+```
+
+Clicking "Waitlist" filters the grid to show only waitlisted users and updates the view title to "Waitlist Members".
+
+## Implementation
+
+**Approach:** Client-side filtering. The existing `/admin/users/data` endpoint already returns each user's `seasons` dict (`{season_id: status}` for all seasons). No backend changes required.
+
+### Files Changed
+
+1. **`app/templates/admin/users.html`** — Add "Waitlist" pill button to the view switcher row (same styling/pattern as existing pills).
+
+2. **`app/static/admin_users.js`** — Three changes:
+   - Add `'waitlist'` as a valid `currentView` value
+   - Implement filter: check if any value in `user.seasons` is `PENDING_LOTTERY` or `DROPPED_LOTTERY`, and no value is `ACTIVE`
+   - Wire up click handler to set view, filter data, and update title to "Waitlist Members"
+
+### Filter Logic (pseudocode)
+
+```javascript
+function isWaitlisted(user) {
+  const statuses = Object.values(user.seasons);
+  const hasLotteryStatus = statuses.some(s =>
+    s === 'PENDING_LOTTERY' || s === 'DROPPED_LOTTERY'
+  );
+  const hasBeenActive = statuses.some(s => s === 'ACTIVE');
+  return hasLotteryStatus && !hasBeenActive;
+}
+```
+
+## Scope
+
+- No backend changes
+- No new endpoints
+- No email functionality (existing CSV export covers that need)
+- Estimated: ~20 lines across 2 files


### PR DESCRIPTION
## Summary
- Adds a "Waitlist" pill button to the admin users view switcher (All | Current | Alumni | **Waitlist**)
- Filters to users who have `PENDING_LOTTERY` or `DROPPED_LOTTERY` in any season but were never `ACTIVE`
- Helps admins quickly identify people who tried to register but never got in, for season registration outreach

## Test plan
- [ ] Navigate to /admin/users and verify "Waitlist" pill appears
- [ ] Click Waitlist and confirm only waitlisted members show
- [ ] Verify other views (All, Current, Alumni) still work
- [ ] Confirm search/role/status filters compose with Waitlist view

🤖 Generated with [Claude Code](https://claude.com/claude-code)