### PR TITLE
fix: registration tier 2 hardening

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -65,9 +65,9 @@ VALID_MEMBER_STATUSES = {'new', 'returning_former'}
 
 # Field length limits
 MAX_NAME_LENGTH = 100
-MAX_PHONE_LENGTH = 30
+MAX_PHONE_LENGTH = 20
 MAX_PRONOUNS_LENGTH = 50
-MAX_RELATION_LENGTH = 100
+MAX_RELATION_LENGTH = 50
 
 # Age limits for date of birth validation
 MIN_MEMBER_AGE = 16

--- a/app/routes/payments.py
+++ b/app/routes/payments.py
@@ -65,7 +65,6 @@ def webhook_received():
 
     try:
         if webhook_secret:
-            # Verify webhook signature and extract the event
             signature = request.headers.get('stripe-signature')
             event = stripe.Webhook.construct_event(
                 payload=request.data,
@@ -73,9 +72,11 @@ def webhook_received():
                 secret=webhook_secret
             )
             data = event['data']
-        else:
+        elif os.getenv('FLASK_ENV') == 'development':
             data = request_data['data']
             event = request_data
+        else:
+            return json_error('Webhook signature verification not configured', 500)
 
         # Get the type of webhook event sent
         event_type = event['type']
@@ -206,16 +207,22 @@ def webhook_received():
             )
 
         elif event_type == StripeEvent.PAYMENT_CANCELED:
-            # Payment was canceled - update status (don't delete, keep for audit)
             payment = Payment.get_by_payment_intent(data_object.id)
             if payment:
                 payment.status = 'canceled'
+                if payment.payment_type == PaymentType.SEASON and payment.season_id:
+                    user = User.get_by_email(payment.email)
+                    if user:
+                        user_season = UserSeason.get_for_user_season(user.id, payment.season_id)
+                        if user_season:
+                            user_season.status = UserSeasonStatus.DROPPED_VOLUNTARY
+                            user.sync_status()
                 db.session.commit()
 
         return json_success()
 
     except Exception as e:
-        return json_error(str(e))
+        return json_error('Webhook processing failed', 500)
 
 @payments.route('/admin/payments/<int:payment_id>/capture', methods=['POST'])
 @admin_required
@@ -461,6 +468,13 @@ def create_season_payment_intent():
         # Derive member_type on the backend
         user = User.get_by_email(email)
         member_type = MemberType.RETURNING.value if user and user.is_returning else MemberType.NEW.value
+        existing_payment = Payment.query.filter(
+            Payment.email == email,
+            Payment.season_id == int(season_id),
+            Payment.status.notin_(['canceled', 'refunded'])
+        ).first()
+        if existing_payment:
+            return json_error('You have already registered for this season.')
         # Determine capture method
         if member_type == MemberType.NEW.value:
             capture_method = 'manual'

--- a/app/routes/registration.py
+++ b/app/routes/registration.py
@@ -64,9 +64,10 @@ def season_register(season_id):
 
             # Get payment_intent_id for coordination with webhook
             payment_intent_id = form.get('payment_intent_id')
-            existing_payment = None
-            if payment_intent_id:
-                existing_payment = Payment.get_by_payment_intent(payment_intent_id)
+            if not payment_intent_id:
+                flash_error('Payment is required to complete registration.')
+                return redirect(url_for('registration.season_register', season_id=season_id))
+            existing_payment = Payment.get_by_payment_intent(payment_intent_id)
 
             # Determine member_type from backend only BEFORE checking dates
             # Check user existence first

--- a/docs/superpowers/plans/2026-04-21-registration-tier2-fixes.md
+++ b/docs/superpowers/plans/2026-04-21-registration-tier2-fixes.md
@@ -1,0 +1,214 @@
+# Registration Tier 2 Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 6 payment/webhook/validation bugs in the season registration flow before launch.
+
+**Architecture:** All changes are surgical edits to three existing files — no new files, no migrations, no new dependencies. Each fix is independent and can be committed separately.
+
+**Tech Stack:** Flask, SQLAlchemy, Stripe API, PostgreSQL
+
+---
+
+### Task 1: Canceled webhook cleans up UserSeason
+
+**Files:**
+- Modify: `app/routes/payments.py:208-213`
+
+- [ ] **Step 1: Update the PAYMENT_CANCELED handler**
+
+Replace lines 208-213 with:
+
+```python
+        elif event_type == StripeEvent.PAYMENT_CANCELED:
+            payment = Payment.get_by_payment_intent(data_object.id)
+            if payment:
+                payment.status = 'canceled'
+                if payment.payment_type == PaymentType.SEASON and payment.season_id:
+                    user = User.get_by_email(payment.email)
+                    if user:
+                        user_season = UserSeason.get_for_user_season(user.id, payment.season_id)
+                        if user_season:
+                            user_season.status = UserSeasonStatus.DROPPED_VOLUNTARY
+                            user.sync_status()
+                db.session.commit()
+```
+
+- [ ] **Step 2: Verify the app starts**
+
+Run: `python -c "from app import create_app; app = create_app(); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/routes/payments.py
+git commit -m "fix: clean up UserSeason when payment hold is canceled"
+```
+
+---
+
+### Task 2: Duplicate registration guard
+
+**Files:**
+- Modify: `app/routes/payments.py:449-495` (`create_season_payment_intent`)
+
+- [ ] **Step 1: Add duplicate check before Stripe call**
+
+After the `member_type` derivation (after line 463) and before the capture method logic (before line 465), add:
+
+```python
+        existing_payment = Payment.query.filter(
+            Payment.email == email,
+            Payment.season_id == int(season_id),
+            Payment.status.notin_(['canceled', 'refunded'])
+        ).first()
+        if existing_payment:
+            return json_error('You have already registered for this season.')
+```
+
+- [ ] **Step 2: Verify the app starts**
+
+Run: `python -c "from app import create_app; app = create_app(); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/routes/payments.py
+git commit -m "fix: prevent duplicate season payment intents"
+```
+
+---
+
+### Task 3: Require payment_intent_id on registration POST
+
+**Files:**
+- Modify: `app/routes/registration.py:65-69`
+
+- [ ] **Step 1: Add required check for payment_intent_id**
+
+Replace lines 65-69 with:
+
+```python
+            payment_intent_id = form.get('payment_intent_id')
+            if not payment_intent_id:
+                flash_error('Payment is required to complete registration.')
+                return redirect(url_for('registration.season_register', season_id=season_id))
+            existing_payment = Payment.get_by_payment_intent(payment_intent_id)
+```
+
+- [ ] **Step 2: Verify the app starts**
+
+Run: `python -c "from app import create_app; app = create_app(); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/routes/registration.py
+git commit -m "fix: require payment_intent_id for registration"
+```
+
+---
+
+### Task 4: Webhook returns 500 on errors
+
+**Files:**
+- Modify: `app/routes/payments.py:217-218`
+
+- [ ] **Step 1: Change error response to 500**
+
+Replace lines 217-218 with:
+
+```python
+    except Exception as e:
+        return json_error('Webhook processing failed', 500)
+```
+
+- [ ] **Step 2: Verify the app starts**
+
+Run: `python -c "from app import create_app; app = create_app(); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/routes/payments.py
+git commit -m "fix: return 500 on webhook errors for Stripe retries"
+```
+
+---
+
+### Task 5: Align validation constants to DB columns
+
+**Files:**
+- Modify: `app/constants.py:68,70`
+
+- [ ] **Step 1: Update the constants**
+
+Change line 68 from `MAX_PHONE_LENGTH = 30` to:
+```python
+MAX_PHONE_LENGTH = 20
+```
+
+Change line 70 from `MAX_RELATION_LENGTH = 100` to:
+```python
+MAX_RELATION_LENGTH = 50
+```
+
+- [ ] **Step 2: Verify the app starts**
+
+Run: `python -c "from app import create_app; app = create_app(); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/constants.py
+git commit -m "fix: align validation constants to DB column sizes"
+```
+
+---
+
+### Task 6: Fail-closed webhook signature verification
+
+**Files:**
+- Modify: `app/routes/payments.py:62-78`
+
+- [ ] **Step 1: Add production guard**
+
+Replace lines 62-78 with:
+
+```python
+def webhook_received():
+    webhook_secret = os.getenv('STRIPE_WEBHOOK_SECRET')
+    request_data = request.get_json()
+
+    try:
+        if webhook_secret:
+            signature = request.headers.get('stripe-signature')
+            event = stripe.Webhook.construct_event(
+                payload=request.data,
+                sig_header=signature,
+                secret=webhook_secret
+            )
+            data = event['data']
+        elif os.getenv('FLASK_ENV') == 'development':
+            data = request_data['data']
+            event = request_data
+        else:
+            return json_error('Webhook signature verification not configured', 500)
+```
+
+- [ ] **Step 2: Verify the app starts**
+
+Run: `python -c "from app import create_app; app = create_app(); print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/routes/payments.py
+git commit -m "fix: reject unverified webhooks outside development"
+```

--- a/docs/superpowers/specs/2026-04-21-registration-tier2-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-21-registration-tier2-fixes-design.md
@@ -1,0 +1,51 @@
+# Registration Tier 2 Fixes — Design Spec
+
+Pre-launch fixes for payment/webhook logic, data integrity, and security in the season registration flow.
+
+## Fix 1: Canceled Webhook Cleans Up UserSeason
+
+**File:** `app/routes/payments.py` lines 208-213
+
+The `payment_intent.canceled` handler only updates `payment.status`. When a hold expires or is canceled externally, the UserSeason stays `PENDING_LOTTERY` forever.
+
+**Change:** After updating payment status, if `payment_type == SEASON` and `season_id` exists, look up the user by email, find their UserSeason, set status to `DROPPED_VOLUNTARY`, and call `sync_status()`. Same pattern as the refund handler (lines 302-309).
+
+## Fix 2: Duplicate Registration Guard
+
+**File:** `app/routes/payments.py` `create_season_payment_intent`
+
+No check prevents creating multiple payment intents for the same email + season.
+
+**Change:** Before creating the Stripe PaymentIntent, query for an existing Payment with matching `email`, `season_id`, and `status` not in `('canceled', 'refunded')`. If found, return a JSON error. This prevents double-charges (returning) and orphaned holds (new).
+
+## Fix 3: Require payment_intent_id on Registration POST
+
+**File:** `app/routes/registration.py` line 66
+
+The `payment_intent_id` field is optional. A direct POST without it creates User + UserSeason with no payment.
+
+**Change:** If `payment_intent_id` is missing or empty, flash an error and redirect back to the form.
+
+## Fix 4: Webhook Returns 500 on Errors
+
+**File:** `app/routes/payments.py` line 217-218
+
+The catch-all returns `json_error(str(e))` which is HTTP 400. Stripe treats 4xx as permanent failures and won't retry.
+
+**Change:** Return `json_error('Webhook processing failed', 500)`. This lets Stripe retry on transient failures without leaking internal error details.
+
+## Fix 5: Align Validation Constants to DB Columns
+
+**File:** `app/constants.py` lines 68, 70
+
+`MAX_PHONE_LENGTH = 30` but `User.phone` is `String(20)`. `MAX_RELATION_LENGTH = 100` but `emergency_contact_relation` is `String(50)`.
+
+**Change:** Set `MAX_PHONE_LENGTH = 20` and `MAX_RELATION_LENGTH = 50`. No migration.
+
+## Fix 6: Fail-Closed Webhook Signature Verification
+
+**File:** `app/routes/payments.py` lines 67-78
+
+When `STRIPE_WEBHOOK_SECRET` is unset, webhooks are accepted without verification.
+
+**Change:** If `webhook_secret` is falsy and `FLASK_ENV != 'development'`, return a 500 error. Only allow unverified webhooks in local development.


### PR DESCRIPTION
## Summary
- Clean up UserSeason status when payment holds are canceled (prevents ghost PENDING_LOTTERY members)
- Prevent duplicate season payment intents (blocks double-charges)
- Require payment_intent_id on registration POST (closes curl bypass)
- Return HTTP 500 on webhook errors so Stripe retries transient failures
- Align validation constants to DB column sizes (phone 20, relation 50)
- Fail-closed webhook signature verification (reject unverified webhooks outside development)

## Test plan
- [ ] Register as returning member — verify single charge, ACTIVE status
- [ ] Register as new member — verify single hold, PENDING_LOTTERY status
- [ ] Attempt duplicate registration with same email — verify "already registered" error
- [ ] Submit registration form without payment — verify rejection
- [ ] Verify webhook signature is required in production (STRIPE_WEBHOOK_SECRET set)
- [ ] Verify phone/relation fields reject inputs longer than DB column sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)