### PR TITLE
fix: registration tier 3 polish — descriptors, times, autocomplete, security

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -100,3 +100,8 @@ def register_template_filters(app):
         if dt is None:
             return ''
         return dt.strftime(fmt)
+
+    @app.template_filter('central_time')
+    def central_time_filter(dt, fmt='%b %d, %Y %I:%M %p CT'):
+        from .utils import format_datetime_central
+        return format_datetime_central(dt, fmt)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -5,9 +5,13 @@ from ..errors import flash_error, flash_success
 
 auth = Blueprint('auth', __name__)
 
+def _is_safe_redirect_url(url):
+    return bool(url) and url.startswith('/') and not url.startswith('//') and '://' not in url
+
 @auth.route('/login')
 def login():
-    session['next_url'] = request.args.get('next') or url_for('admin.get_admin_page')
+    next_url = request.args.get('next')
+    session['next_url'] = next_url if _is_safe_redirect_url(next_url) else url_for('admin.get_admin_page')
     redirect_uri = url_for('auth.authorize', _external=True)
     return oauth.google.authorize_redirect(redirect_uri)
 

--- a/app/routes/payments.py
+++ b/app/routes/payments.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, jsonify, request
+import re
 import stripe
 import os
 from ..models import db, Payment, Season, UserSeason, User, Trip, SocialEvent
@@ -9,6 +10,11 @@ from ..utils import normalize_email, today_central
 from ..notifications.slack import send_payment_notification
 
 payments = Blueprint('payments', __name__)
+
+def build_statement_descriptor(payment_type, identifier):
+    prefix = f"TCSC_{payment_type}_"
+    sanitized = re.sub(r'[^A-Z0-9_ .\-]', '', identifier.upper())
+    return (prefix + sanitized)[:22]
 
 @payments.route('/get-stripe-key')
 def get_stripe_key():
@@ -36,6 +42,8 @@ def create_payment():
             currency='usd',
             capture_method='manual',  # Always manual for trips (lottery system)
             receipt_email=email,
+            statement_descriptor=build_statement_descriptor('TRIP', trip.name if trip else 'UNKNOWN'),
+            description=f"TCSC Trip - {trip.name}" if trip else "TCSC Trip Registration",
             metadata={
                 'name': name,
                 'email': email,
@@ -487,6 +495,7 @@ def create_season_payment_intent():
             currency='usd',
             capture_method=capture_method,
             receipt_email=email,
+            statement_descriptor=build_statement_descriptor('SEASON', str(season.year)),
             description=f"TCSC {season.name} Membership",
             metadata={
                 'name': name,
@@ -534,6 +543,8 @@ def create_social_event_payment_intent():
             currency='usd',
             capture_method='automatic',  # Immediate charge - no lottery
             receipt_email=email,
+            statement_descriptor=build_statement_descriptor('SOCIAL', social_event.name),
+            description=f"TCSC Social Event - {social_event.name}",
             metadata={
                 'name': name,
                 'email': email,

--- a/app/routes/payments.py
+++ b/app/routes/payments.py
@@ -309,7 +309,7 @@ def refund_payment(payment_id):
             )
 
             # Verify the refund was successful
-            if refund.status != 'succeeded':
+            if refund.status not in ('succeeded', 'pending'):
                 return json_error(f'Refund failed - status: {refund.status}')
 
             payment.status = 'refunded'
@@ -432,7 +432,7 @@ def bulk_refund_payments():
                     payment.status = canceled_intent.status
                 else:
                     refund = stripe.Refund.create(payment_intent=payment.payment_intent_id)
-                    if refund.status != 'succeeded':
+                    if refund.status not in ('succeeded', 'pending'):
                         results.append({'id': payment_id, 'success': False, 'error': f'Refund failed - status: {refund.status}'})
                         continue
                     payment.status = 'refunded'

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -39,15 +39,15 @@
               {% if is_season_registration_open %}
                 <span class="status-open">Registration is open!</span>
                 {% if season.returning_start and season.returning_end and season.returning_start <= now <= season.returning_end %}
-                    <span class="sub-status">Returning member window closes {{ season.returning_end.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+                    <span class="sub-status">Returning member window closes {{ season.returning_end|central_time }}.</span>
                 {% endif %}
                 {% if season.new_start and season.new_end and season.new_start <= now <= season.new_end %}
-                    <span class="sub-status">New member window closes {{ season.new_end.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+                    <span class="sub-status">New member window closes {{ season.new_end|central_time }}.</span>
                 {% endif %}
               {% elif season.returning_start and season.returning_start > now %}
-                <span class="status-upcoming">Registration opens for returning members on {{ season.returning_start.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+                <span class="status-upcoming">Registration opens for returning members on {{ season.returning_start|central_time }}.</span>
               {% elif season.new_start and season.new_start > now %}
-                <span class="status-upcoming">Registration opens for new members on {{ season.new_start.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+                <span class="status-upcoming">Registration opens for new members on {{ season.new_start|central_time }}.</span>
               {% else %}{# Must be closed (after end dates) #}
                 <span class="status-closed">Registration is currently closed.</span>
               {% endif %}

--- a/app/templates/season_detail.html
+++ b/app/templates/season_detail.html
@@ -57,15 +57,15 @@
             {% if is_registration_open %}
               <span class="status-open">Registration is open!</span>
               {% if season.returning_start and season.returning_end and season.returning_start <= now <= season.returning_end %}
-                  <span class="sub-status">Returning member window closes {{ season.returning_end.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+                  <span class="sub-status">Returning member window closes {{ season.returning_end|central_time }}.</span>
               {% endif %}
               {% if season.new_start and season.new_end and season.new_start <= now <= season.new_end %}
-                  <span class="sub-status">New member window closes {{ season.new_end.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+                  <span class="sub-status">New member window closes {{ season.new_end|central_time }}.</span>
               {% endif %}
             {% elif season.returning_start and season.returning_start > now %}
-              <span class="status-upcoming">Registration opens for returning members on {{ season.returning_start.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+              <span class="status-upcoming">Registration opens for returning members on {{ season.returning_start|central_time }}.</span>
             {% elif season.new_start and season.new_start > now %}
-              <span class="status-upcoming">Registration opens for new members on {{ season.new_start.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+              <span class="status-upcoming">Registration opens for new members on {{ season.new_start|central_time }}.</span>
             {% else %}{# Must be closed (after end dates) #}
               <span class="status-closed">Registration is currently closed.</span>
             {% endif %}

--- a/app/templates/season_register.html
+++ b/app/templates/season_register.html
@@ -58,11 +58,11 @@
               </div>
               <div class="sr-form-row form-group">
                 <label for="firstName">First Name</label>
-                <input class="sr-input" type="text" id="firstName" name="firstName" placeholder="First Name" required>
+                <input class="sr-input" type="text" id="firstName" name="firstName" placeholder="First Name" autocomplete="given-name" required>
               </div>
               <div class="sr-form-row form-group">
                 <label for="lastName">Last Name</label>
-                <input class="sr-input" type="text" id="lastName" name="lastName" placeholder="Last Name" required>
+                <input class="sr-input" type="text" id="lastName" name="lastName" placeholder="Last Name" autocomplete="family-name" required>
               </div>
               <div class="sr-form-row form-group">
                 <label for="pronouns">Pronouns (Optional)</label>
@@ -70,11 +70,11 @@
               </div>
               <div class="sr-form-row form-group">
                 <label for="dob">Date of Birth</label>
-                <input class="sr-input" type="date" id="dob" name="dob" placeholder="Date of Birth" required>
+                <input class="sr-input" type="date" id="dob" name="dob" placeholder="Date of Birth" autocomplete="bday" required>
               </div>
               <div class="sr-form-row form-group">
                 <label for="phone">Phone Number</label>
-                <input class="sr-input" type="tel" id="phone" name="phone" placeholder="Phone Number" required>
+                <input class="sr-input" type="tel" id="phone" name="phone" placeholder="Phone Number" autocomplete="tel" required>
               </div>
               <div class="sr-form-row form-group">
                 <label for="tshirtSize" class="sr-only">T-Shirt Size</label>
@@ -114,19 +114,19 @@
               <legend>Emergency Contact</legend>
               <div class="sr-form-row form-group">
                 <label for="emergencyName">Contact's Full Name</label>
-                <input class="sr-input" type="text" id="emergencyName" name="emergencyName" placeholder="Contact's Full Name" required>
+                <input class="sr-input" type="text" id="emergencyName" name="emergencyName" placeholder="Contact's Full Name" autocomplete="off" required>
               </div>
               <div class="sr-form-row form-group">
                 <label for="emergencyRelation">Relationship</label>
-                <input class="sr-input" type="text" id="emergencyRelation" name="emergencyRelation" placeholder="Relationship" required>
+                <input class="sr-input" type="text" id="emergencyRelation" name="emergencyRelation" placeholder="Relationship" autocomplete="off" required>
               </div>
               <div class="sr-form-row form-group">
                 <label for="emergencyPhone">Contact's Phone Number</label>
-                <input class="sr-input" type="tel" id="emergencyPhone" name="emergencyPhone" placeholder="Contact's Phone Number" required>
+                <input class="sr-input" type="tel" id="emergencyPhone" name="emergencyPhone" placeholder="Contact's Phone Number" autocomplete="off" required>
               </div>
               <div class="sr-form-row form-group">
                 <label for="emergencyEmail">Contact's Email Address</label>
-                <input class="sr-input" type="email" id="emergencyEmail" name="emergencyEmail" placeholder="Contact's Email Address" required>
+                <input class="sr-input" type="email" id="emergencyEmail" name="emergencyEmail" placeholder="Contact's Email Address" autocomplete="off" required>
               </div>
             </fieldset>
 
@@ -134,7 +134,7 @@
               <legend>Payment Details</legend>
               <div class="sr-form-row form-group">
                 <label for="name">Full Name (for card)</label>
-                <input class="sr-input" type="text" id="name" name="name" placeholder="Full Name" autocomplete="cardholder" required />
+                <input class="sr-input" type="text" id="name" name="name" placeholder="Full Name" autocomplete="cc-name" required />
               </div>
               <div class="sr-form-row form-group">
                 <label for="card-element">Card Details</label>

--- a/docs/superpowers/plans/2026-04-20-registration-tier3-fixes.md
+++ b/docs/superpowers/plans/2026-04-20-registration-tier3-fixes.md
@@ -1,0 +1,432 @@
+# Registration Tier 3 Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Six independent polish/security fixes from the registration validation audit — statement descriptors, Central time display, autocomplete attributes, open redirect fix, refund pending status, and cardholder autocomplete.
+
+**Architecture:** All fixes are independent single-file or two-file changes. No new models, no migrations, no new dependencies. The fixes touch `payments.py`, `auth.py`, `__init__.py`, `index.html`, `season_detail.html`, and `season_register.html`.
+
+**Tech Stack:** Flask, Stripe API, Jinja2 template filters, pytz (already in use)
+
+---
+
+### Task 1: Statement Descriptor on PaymentIntents
+
+**Files:**
+- Modify: `app/routes/payments.py:1-2` (add `import re`)
+- Modify: `app/routes/payments.py:17-59` (trip PaymentIntent — add descriptor + description)
+- Modify: `app/routes/payments.py:485-498` (season PaymentIntent — add descriptor)
+- Modify: `app/routes/payments.py:532-544` (social PaymentIntent — add descriptor + description)
+
+- [ ] **Step 1: Add helper function and import**
+
+At the top of `app/routes/payments.py`, add `import re` to the imports, then add the helper function before the first route:
+
+```python
+import re
+
+def build_statement_descriptor(payment_type, identifier):
+    prefix = f"TCSC_{payment_type}_"
+    sanitized = re.sub(r'[^A-Z0-9_ .\-]', '', identifier.upper())
+    return (prefix + sanitized)[:22]
+```
+
+Place this function after the `payments = Blueprint(...)` line and before the first `@payments.route`.
+
+- [ ] **Step 2: Add descriptor to trip PaymentIntent**
+
+In the `create_payment()` function, add `statement_descriptor` and `description` to the `stripe.PaymentIntent.create()` call. Find:
+
+```python
+        intent = stripe.PaymentIntent.create(
+            amount=int(amount * 100),  # Convert to cents
+            currency='usd',
+            capture_method='manual',  # Always manual for trips (lottery system)
+            receipt_email=email,
+```
+
+Replace with:
+
+```python
+        intent = stripe.PaymentIntent.create(
+            amount=int(amount * 100),  # Convert to cents
+            currency='usd',
+            capture_method='manual',  # Always manual for trips (lottery system)
+            receipt_email=email,
+            statement_descriptor=build_statement_descriptor('TRIP', trip.name if trip else 'UNKNOWN'),
+            description=f"TCSC Trip - {trip.name}" if trip else "TCSC Trip Registration",
+```
+
+- [ ] **Step 3: Add descriptor to season PaymentIntent**
+
+In the `create_season_payment_intent()` function, find:
+
+```python
+        intent = stripe.PaymentIntent.create(
+            amount=season.price_cents,
+            currency='usd',
+            capture_method=capture_method,
+            receipt_email=email,
+            description=f"TCSC {season.name} Membership",
+```
+
+Replace with:
+
+```python
+        intent = stripe.PaymentIntent.create(
+            amount=season.price_cents,
+            currency='usd',
+            capture_method=capture_method,
+            receipt_email=email,
+            statement_descriptor=build_statement_descriptor('SEASON', str(season.year)),
+            description=f"TCSC {season.name} Membership",
+```
+
+- [ ] **Step 4: Add descriptor and description to social event PaymentIntent**
+
+In the `create_social_event_payment_intent()` function, find:
+
+```python
+        intent = stripe.PaymentIntent.create(
+            amount=social_event.price,
+            currency='usd',
+            capture_method='automatic',  # Immediate charge - no lottery
+            receipt_email=email,
+```
+
+Replace with:
+
+```python
+        intent = stripe.PaymentIntent.create(
+            amount=social_event.price,
+            currency='usd',
+            capture_method='automatic',  # Immediate charge - no lottery
+            receipt_email=email,
+            statement_descriptor=build_statement_descriptor('SOCIAL', social_event.name),
+            description=f"TCSC Social Event - {social_event.name}",
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/routes/payments.py
+git commit -m "feat: add statement descriptors and descriptions to PaymentIntents"
+```
+
+---
+
+### Task 2: Central Time Display for Registration Windows
+
+**Files:**
+- Modify: `app/__init__.py:71-102` (add template filter)
+- Modify: `app/templates/index.html:42,45,48,50` (replace UTC with filter)
+- Modify: `app/templates/season_detail.html:60,63,66,68` (replace UTC with filter)
+
+- [ ] **Step 1: Add central_time template filter**
+
+In `app/__init__.py`, inside the `register_template_filters(app)` function, add the following after the existing `format_date` filter (after line 102):
+
+```python
+    @app.template_filter('central_time')
+    def central_time_filter(dt, fmt='%b %d, %Y %I:%M %p CT'):
+        from .utils import format_datetime_central
+        return format_datetime_central(dt, fmt)
+```
+
+- [ ] **Step 2: Update index.html — replace 4 UTC occurrences**
+
+In `app/templates/index.html`, replace each of these 4 lines:
+
+Line 42 — find:
+```html
+<span class="sub-status">Returning member window closes {{ season.returning_end.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+```
+Replace with:
+```html
+<span class="sub-status">Returning member window closes {{ season.returning_end|central_time }}.</span>
+```
+
+Line 45 — find:
+```html
+<span class="sub-status">New member window closes {{ season.new_end.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+```
+Replace with:
+```html
+<span class="sub-status">New member window closes {{ season.new_end|central_time }}.</span>
+```
+
+Line 48 — find:
+```html
+<span class="status-upcoming">Registration opens for returning members on {{ season.returning_start.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+```
+Replace with:
+```html
+<span class="status-upcoming">Registration opens for returning members on {{ season.returning_start|central_time }}.</span>
+```
+
+Line 50 — find:
+```html
+<span class="status-upcoming">Registration opens for new members on {{ season.new_start.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+```
+Replace with:
+```html
+<span class="status-upcoming">Registration opens for new members on {{ season.new_start|central_time }}.</span>
+```
+
+- [ ] **Step 3: Update season_detail.html — replace 4 UTC occurrences**
+
+In `app/templates/season_detail.html`, make the same 4 replacements:
+
+Line 60 — find:
+```html
+<span class="sub-status">Returning member window closes {{ season.returning_end.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+```
+Replace with:
+```html
+<span class="sub-status">Returning member window closes {{ season.returning_end|central_time }}.</span>
+```
+
+Line 63 — find:
+```html
+<span class="sub-status">New member window closes {{ season.new_end.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+```
+Replace with:
+```html
+<span class="sub-status">New member window closes {{ season.new_end|central_time }}.</span>
+```
+
+Line 66 — find:
+```html
+<span class="status-upcoming">Registration opens for returning members on {{ season.returning_start.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+```
+Replace with:
+```html
+<span class="status-upcoming">Registration opens for returning members on {{ season.returning_start|central_time }}.</span>
+```
+
+Line 68 — find:
+```html
+<span class="status-upcoming">Registration opens for new members on {{ season.new_start.strftime('%b %d, %Y %I:%M %p UTC') }}.</span>
+```
+Replace with:
+```html
+<span class="status-upcoming">Registration opens for new members on {{ season.new_start|central_time }}.</span>
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/__init__.py app/templates/index.html app/templates/season_detail.html
+git commit -m "fix: display registration window times in Central instead of UTC"
+```
+
+---
+
+### Task 3: Autocomplete Attributes on Registration Form
+
+**Files:**
+- Modify: `app/templates/season_register.html` (10 input fields)
+
+- [ ] **Step 1: Add autocomplete to personal info fields**
+
+In `app/templates/season_register.html`, update these 4 inputs:
+
+Find:
+```html
+<input class="sr-input" type="text" id="firstName" name="firstName" placeholder="First Name" required>
+```
+Replace with:
+```html
+<input class="sr-input" type="text" id="firstName" name="firstName" placeholder="First Name" autocomplete="given-name" required>
+```
+
+Find:
+```html
+<input class="sr-input" type="text" id="lastName" name="lastName" placeholder="Last Name" required>
+```
+Replace with:
+```html
+<input class="sr-input" type="text" id="lastName" name="lastName" placeholder="Last Name" autocomplete="family-name" required>
+```
+
+Find:
+```html
+<input class="sr-input" type="date" id="dob" name="dob" placeholder="Date of Birth" required>
+```
+Replace with:
+```html
+<input class="sr-input" type="date" id="dob" name="dob" placeholder="Date of Birth" autocomplete="bday" required>
+```
+
+Find:
+```html
+<input class="sr-input" type="tel" id="phone" name="phone" placeholder="Phone Number" required>
+```
+Replace with:
+```html
+<input class="sr-input" type="tel" id="phone" name="phone" placeholder="Phone Number" autocomplete="tel" required>
+```
+
+- [ ] **Step 2: Add autocomplete="off" to emergency contact fields**
+
+Find:
+```html
+<input class="sr-input" type="text" id="emergencyName" name="emergencyName" placeholder="Contact's Full Name" required>
+```
+Replace with:
+```html
+<input class="sr-input" type="text" id="emergencyName" name="emergencyName" placeholder="Contact's Full Name" autocomplete="off" required>
+```
+
+Find:
+```html
+<input class="sr-input" type="text" id="emergencyRelation" name="emergencyRelation" placeholder="Relationship" required>
+```
+Replace with:
+```html
+<input class="sr-input" type="text" id="emergencyRelation" name="emergencyRelation" placeholder="Relationship" autocomplete="off" required>
+```
+
+Find:
+```html
+<input class="sr-input" type="tel" id="emergencyPhone" name="emergencyPhone" placeholder="Contact's Phone Number" required>
+```
+Replace with:
+```html
+<input class="sr-input" type="tel" id="emergencyPhone" name="emergencyPhone" placeholder="Contact's Phone Number" autocomplete="off" required>
+```
+
+Find:
+```html
+<input class="sr-input" type="email" id="emergencyEmail" name="emergencyEmail" placeholder="Contact's Email Address" required>
+```
+Replace with:
+```html
+<input class="sr-input" type="email" id="emergencyEmail" name="emergencyEmail" placeholder="Contact's Email Address" autocomplete="off" required>
+```
+
+- [ ] **Step 3: Fix cardholder autocomplete (Fix 25)**
+
+In the same file, find:
+```html
+<input class="sr-input" type="text" id="name" name="name" placeholder="Full Name" autocomplete="cardholder" required />
+```
+Replace with:
+```html
+<input class="sr-input" type="text" id="name" name="name" placeholder="Full Name" autocomplete="cc-name" required />
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/templates/season_register.html
+git commit -m "fix: add standard autocomplete attributes to registration form inputs"
+```
+
+---
+
+### Task 4: Open Redirect in OAuth Login
+
+**Files:**
+- Modify: `app/routes/auth.py:1-12` (add validation, apply to login route)
+
+- [ ] **Step 1: Add URL validation and apply to login route**
+
+In `app/routes/auth.py`, add the validation function and update the login route. Find:
+
+```python
+@auth.route('/login')
+def login():
+    session['next_url'] = request.args.get('next') or url_for('admin.get_admin_page')
+```
+
+Replace with:
+
+```python
+def _is_safe_redirect_url(url):
+    return bool(url) and url.startswith('/') and not url.startswith('//') and '://' not in url
+
+@auth.route('/login')
+def login():
+    next_url = request.args.get('next')
+    session['next_url'] = next_url if _is_safe_redirect_url(next_url) else url_for('admin.get_admin_page')
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/routes/auth.py
+git commit -m "fix: validate OAuth next_url to prevent open redirect"
+```
+
+---
+
+### Task 5: Stripe Refund Pending Status
+
+**Files:**
+- Modify: `app/routes/payments.py:304-305` (individual refund)
+- Modify: `app/routes/payments.py:427-429` (bulk refund)
+
+- [ ] **Step 1: Fix individual refund handler**
+
+In `app/routes/payments.py`, find the individual refund check:
+
+```python
+            if refund.status != 'succeeded':
+                return json_error(f'Refund failed - status: {refund.status}')
+```
+
+Replace with:
+
+```python
+            if refund.status not in ('succeeded', 'pending'):
+                return json_error(f'Refund failed - status: {refund.status}')
+```
+
+- [ ] **Step 2: Fix bulk refund handler**
+
+In the same file, find the bulk refund check:
+
+```python
+                    if refund.status != 'succeeded':
+                        results.append({'id': payment_id, 'success': False, 'error': f'Refund failed - status: {refund.status}'})
+                        continue
+```
+
+Replace with:
+
+```python
+                    if refund.status not in ('succeeded', 'pending'):
+                        results.append({'id': payment_id, 'success': False, 'error': f'Refund failed - status: {refund.status}'})
+                        continue
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/routes/payments.py
+git commit -m "fix: accept Stripe refund 'pending' status as success"
+```
+
+---
+
+### Task 6: Verify All Changes
+
+- [ ] **Step 1: Run existing tests to verify no regressions**
+
+```bash
+cd /Users/rob/env/tcsc-trips
+python -m pytest tests/ -v --tb=short
+```
+
+Expected: All existing tests pass. None of our changes touch tested code paths.
+
+- [ ] **Step 2: Quick smoke test — verify app starts**
+
+```bash
+cd /Users/rob/env/tcsc-trips
+source env/bin/activate
+FLASK_ENV=development python -c "from app import create_app; app = create_app(); print('App created OK')"
+```
+
+Expected: `App created OK` — confirms the template filter registration and payments.py import changes don't break app startup.

--- a/docs/superpowers/specs/2026-04-20-registration-tier3-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-20-registration-tier3-fixes-design.md
@@ -1,0 +1,103 @@
+# Registration Tier 3 Fixes — Design Spec
+
+Six independent polish/security fixes from the 10-agent registration validation audit.
+
+## Fix 14: Statement Descriptor on PaymentIntents
+
+**Pattern:** `TCSC_SEASON_2026`, `TCSC_TRIP_BIRKIE`, `TCSC_SOCIAL_YOGA`
+
+Stripe limits `statement_descriptor` to 22 characters. Only allows alphanumeric, spaces, and `_`, `-`, `.`.
+
+**Helper function** in `payments.py`:
+
+```python
+def build_statement_descriptor(payment_type, identifier):
+    prefix = f"TCSC_{payment_type}_"
+    sanitized = re.sub(r'[^A-Z0-9_ .-]', '', identifier.upper())
+    descriptor = (prefix + sanitized)[:22]
+    return descriptor
+```
+
+**Apply to all three PaymentIntent.create() calls:**
+- Season: `build_statement_descriptor("SEASON", str(season.year))` → `TCSC_SEASON_2026`
+- Trip: `build_statement_descriptor("TRIP", trip.name)` → `TCSC_TRIP_BIRKIE` (truncated at 22)
+- Social: `build_statement_descriptor("SOCIAL", social_event.name)` → `TCSC_SOCIAL_YOGA`
+
+Also add `description` to trip and social event intents (season already has one from Tier 2 fix):
+- Trip: `f"TCSC Trip - {trip.name}"`
+- Social: `f"TCSC Social Event - {social_event.name}"`
+
+**Files:** `app/routes/payments.py`
+
+## Fix 20: Central Time Display for Registration Windows
+
+Register `format_datetime_central` from `app/utils.py` as a Jinja template filter named `central_time`. The function already handles naive-UTC-to-Central conversion.
+
+**In `app/__init__.py`:**
+```python
+@app.template_filter('central_time')
+def central_time_filter(dt, fmt='%b %d, %Y %I:%M %p CT'):
+    return format_datetime_central(dt, fmt)
+```
+
+**Replace in templates** (8 occurrences total):
+- `index.html` lines 42, 45, 48, 50: Change `season.X.strftime('%b %d, %Y %I:%M %p UTC')` to `season.X|central_time`
+- `season_detail.html` lines 60, 63, 66, 68: Same replacement
+
+Display format: `"Oct 15, 2026 11:59 PM CT"` — uses "CT" instead of timezone-aware "%Z" (which would show "CDT"/"CST" depending on DST) to keep it simple for members.
+
+**Files:** `app/__init__.py`, `app/templates/index.html`, `app/templates/season_detail.html`
+
+## Fix 21: Autocomplete Attributes on Registration Form
+
+Add standard HTML autocomplete attributes to `season_register.html` inputs:
+
+| Input | Current | New `autocomplete` |
+|-------|---------|-------------------|
+| `firstName` | (none) | `given-name` |
+| `lastName` | (none) | `family-name` |
+| `phone` | (none) | `tel` |
+| `dob` | (none) | `bday` |
+| `pronouns` | (none) | (leave as-is, no standard value) |
+| `tshirtSize` | (none) | (leave as-is, no standard value) |
+| `emergencyName` | (none) | `off` |
+| `emergencyRelation` | (none) | `off` |
+| `emergencyPhone` | (none) | `off` |
+| `emergencyEmail` | (none) | `off` |
+
+Emergency contact fields use `off` to prevent browsers from autofilling the user's own info into contact fields.
+
+**Files:** `app/templates/season_register.html`
+
+## Fix 23: Open Redirect in OAuth Login
+
+Validate `next` parameter in `auth.py` login route. Only accept relative URLs (start with `/`, don't start with `//`, don't contain `://`).
+
+```python
+def is_safe_redirect_url(url):
+    if not url:
+        return False
+    return url.startswith('/') and not url.startswith('//') and '://' not in url
+```
+
+Apply in the login route: if `next` param fails validation, fall back to admin page URL.
+
+**Files:** `app/routes/auth.py`
+
+## Fix 24: Stripe Refund Pending Status
+
+Stripe can return `refund.status = 'pending'` for bank-originated refunds. Current code treats anything other than `'succeeded'` as failure.
+
+Change the check in two places:
+- `payments.py:304` (individual refund): `if refund.status not in ('succeeded', 'pending'):`
+- `payments.py:427` (bulk refund): same change
+
+In both cases, set local `payment.status = 'refunded'` regardless of whether Stripe says `succeeded` or `pending` — the refund is initiated and will complete.
+
+**Files:** `app/routes/payments.py`
+
+## Fix 25: Cardholder Autocomplete
+
+Change `autocomplete="cardholder"` to `autocomplete="cc-name"` on the cardholder name input in the registration form. `cc-name` is the W3C standard value for credit card holder name.
+
+**Files:** `app/templates/season_register.html`


### PR DESCRIPTION
## Summary
- Add `statement_descriptor` to all Stripe PaymentIntents so members can identify charges on bank statements (e.g., `TCSC_SEASON_2026`, `TCSC_TRIP_BIRKIE`)
- Display registration window times in Central instead of UTC across homepage and season detail pages
- Add standard `autocomplete` attributes to all registration form inputs for mobile autofill
- Fix open redirect vulnerability in OAuth login flow by validating the `next` parameter
- Accept Stripe refund `pending` status as success (bank-originated refunds)
- Fix cardholder name field to use W3C standard `autocomplete="cc-name"`

## Test plan
- [ ] Verify registration page form inputs trigger browser autofill on mobile
- [ ] Verify homepage and season detail show times in Central (not UTC)
- [ ] Verify `/login?next=https://evil.com` redirects to admin page (not evil.com)
- [ ] Verify Stripe test payments show statement descriptor in Stripe Dashboard
- [ ] Run existing test suite — 35/35 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)