### PR TITLE
feat: add club name and subtitle to homepage header

### DIFF
--- a/app/static/css/styles/components/_layout.css
+++ b/app/static/css/styles/components/_layout.css
@@ -15,6 +15,31 @@
   height: 48px;
 }
 
+.page-header--home {
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px 32px 28px;
+}
+
+.page-header__logo--small {
+  height: 32px;
+}
+
+.page-header__text {
+  text-align: center;
+}
+
+.page-header__title {
+  font: 700 20px var(--font-stack);
+  color: var(--text-primary);
+}
+
+.page-header__subtitle {
+  font: 14px var(--font-stack);
+  color: var(--text-muted);
+  margin: 3px 0 0;
+}
+
 .page-content {
   max-width: 720px;
   margin: 0 auto;

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,16 +11,20 @@
   </head>
   <body>
     <div class="page">
-      <header class="page-header">
-        <img src="{{ url_for('static', filename='images/tcsc-logo.svg') }}" alt="TCSC Logo" class="page-header__logo">
+      <header class="page-header page-header--home">
+        <img src="{{ url_for('static', filename='images/tcsc-logo.svg') }}" alt="TCSC Logo" class="page-header__logo page-header__logo--small">
+        <div class="page-header__text">
+          <h1 class="page-header__title">Twin Cities Ski Club</h1>
+          <p class="page-header__subtitle">Register for seasons, trips, and events</p>
+        </div>
       </header>
 
       <div class="page-content">
         {% if season %}
         <div class="homepage-section">
-          <div class="section-pill section-pill--membership">Membership</div>
+          <div class="section-pill section-pill--membership">Season</div>
           <div style="margin-top: 16px;">
-            <div class="card">
+            <a href="/seasons/{{ season.id }}" class="card" style="text-decoration: none;">
               <div class="card__header">
                 <span class="card__title">{{ season.name }}</span>
                 {% if is_season_registration_open %}
@@ -55,12 +59,12 @@
                   <span class="card__price"></span>
                 {% endif %}
                 {% if is_season_registration_open %}
-                  <a href="/seasons/{{ season.id }}" class="btn btn--small">Register</a>
+                  <span class="btn btn--small">Register</span>
                 {% else %}
-                  <a href="/seasons/{{ season.id }}" class="btn btn--small btn--secondary">Season Info</a>
+                  <span class="btn btn--small btn--secondary">Season Info</span>
                 {% endif %}
               </div>
-            </div>
+            </a>
           </div>
         </div>
         {% endif %}


### PR DESCRIPTION
## Summary
- Adds "Twin Cities Ski Club" title and "Register for seasons, trips, and events" subtitle to the homepage header, stacked below the logo
- Shrinks the logo from 48px to 32px on the homepage for better visual balance
- Makes the season card fully clickable (matches trip/social card pattern)
- Renames the season section pill from "Membership" to "Season"

## Test plan
- [ ] Verify homepage header shows logo, title, and subtitle with proper spacing
- [ ] Verify season card is fully clickable and navigates to season detail
- [ ] Verify pill reads "Season"
- [ ] Verify other pages with `page-header` are unaffected (uses `--home` modifier)
- [ ] Check mobile layout looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)