### PR TITLE
fix: simplify registration text and add Slack notice

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -41,16 +41,15 @@
                 <span class="card__meta-item">📅 {{ season.start_date.strftime('%b %d, %Y') }} — {{ season.end_date.strftime('%b %d, %Y') }}</span>
               </div>
               {% if is_season_registration_open %}
-                {% if season.returning_start and season.returning_end and season.returning_start <= now <= season.returning_end %}
-                  <span class="card__subtext">Returning member window closes {{ season.returning_end|central_time }}.</span>
-                {% endif %}
-                {% if season.new_start and season.new_end and season.new_start <= now <= season.new_end %}
-                  <span class="card__subtext">New member window closes {{ season.new_end|central_time }}.</span>
+                {% if season.new_end %}
+                  <span class="card__subtext">Registration closes {{ season.new_end|central_time }}.</span>
+                {% elif season.returning_end %}
+                  <span class="card__subtext">Registration closes {{ season.returning_end|central_time }}.</span>
                 {% endif %}
               {% elif season.returning_start and season.returning_start > now %}
-                <span class="card__subtext">Registration opens for returning members on {{ season.returning_start|central_time }}.</span>
+                <span class="card__subtext">Registration opens {{ season.returning_start|central_time }}.</span>
               {% elif season.new_start and season.new_start > now %}
-                <span class="card__subtext">Registration opens for new members on {{ season.new_start|central_time }}.</span>
+                <span class="card__subtext">Registration opens {{ season.new_start|central_time }}.</span>
               {% endif %}
               <div class="card__footer">
                 {% if season.price_cents %}

--- a/app/templates/season_success.html
+++ b/app/templates/season_success.html
@@ -25,6 +25,10 @@
             <p style="margin: 0 0 8px;">A hold of <strong>{{ amount_display }}</strong> has been placed on your card. Your card will <strong>not</strong> be charged until your membership is confirmed.</p>
             <p style="margin: 0;">You'll receive a receipt email from Stripe once your membership is confirmed and the charge is processed.</p>
           </div>
+          <div class="notice notice--info" style="margin-top: 12px;">
+            <p style="margin: 0 0 8px;"><strong>Next up: join us on Slack!</strong></p>
+            <p style="margin: 0;">You'll receive an invite to the TCSC Slack workspace shortly. Please install the <a href="https://slack.com/downloads" target="_blank">Slack app</a> on your phone — it's where all club communication, announcements, and community activity happens.</p>
+          </div>
           <div class="notice notice--warn" style="margin-top: 12px;">
             <strong>Tip:</strong> Save this page or take a screenshot for your records.
           </div>


### PR DESCRIPTION
## Summary
- Simplifies homepage card to show "Registration closes [date]" instead of member-type-specific window text
- Simplifies "Registration opens" text to drop the "for returning/new members" qualifier
- Adds Slack onboarding notice on the success page for new members (payment hold path only)

## Test plan
- [ ] Verify homepage card shows generic "Registration closes [date]" when registration is open
- [ ] Verify "Registration opens [date]" text when registration is upcoming
- [ ] Verify new member success page shows Slack install notice
- [ ] Verify returning member success page does NOT show Slack notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)