### PR TITLE
fix: prevent new member registration before their window opens

### DIFF
--- a/app/routes/registration.py
+++ b/app/routes/registration.py
@@ -215,4 +215,8 @@ def api_is_returning_member():
     email = normalize_email(data.get('email', ''))
     user = User.get_by_email(email)
     is_returning = bool(user and getattr(user, 'is_returning', False))
-    return jsonify({'is_returning': is_returning}) 
+    result = {'is_returning': is_returning}
+    if not is_returning:
+        season = Season.get_current()
+        result['new_registration_open'] = bool(season and season.is_new_open())
+    return jsonify(result)

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -302,12 +302,17 @@ document.addEventListener('DOMContentLoaded', () => {
         if (data.is_returning) {
           emailStatusMsg.textContent = '✅ Returning/Former Member';
           emailStatusMsg.style.color = '#166534';
-          // Auto-select the returning member radio
           if (returningRadio) returningRadio.checked = true;
+          const submitBtn = document.getElementById('register-btn');
+          if (submitBtn) submitBtn.disabled = false;
+        } else if (data.new_registration_open === false) {
+          emailStatusMsg.textContent = '⚠️ Registration for new members is not yet open. Please check back when the new member registration window begins.';
+          emailStatusMsg.style.color = '#b07b2c';
+          const submitBtn = document.getElementById('register-btn');
+          if (submitBtn) submitBtn.disabled = true;
         } else {
           emailStatusMsg.textContent = '⚠️ We couldn\'t find your email in our returning member records. Please register as a new member or try a different email address if you believe this is a mistake.';
           emailStatusMsg.style.color = '#b07b2c';
-          // Auto-select the new member radio
           if (newMemberRadio) newMemberRadio.checked = true;
         }
       } catch (err) {

--- a/docs/superpowers/plans/2026-04-24-channel-sync-redesign.md
+++ b/docs/superpowers/plans/2026-04-24-channel-sync-redesign.md
@@ -1,0 +1,1355 @@
+# Channel Sync Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Use the opus model for all executing agents.**
+
+**Goal:** Redesign the Slack channel sync to support activity-based tier decisions for 2+ season alumni, self-service reactivation via Slack Custom Steps, and private channel preservation during full_member → MCG transitions.
+
+**Architecture:** The existing `channel_sync.py` orchestrates a 3am daily sync using cookie-based admin APIs. We add an activity-fetch step early in the sync, update `User.get_slack_tier()` to incorporate a 90-day activity check via `SlackUser.last_slack_activity`, modify `sync_single_user()` to preserve private channels during MCG transitions, add a Bolt custom function handler for reactivation, and add webhook notifications for tier transitions. Config changes in `slack_channels.yaml` update the channel-to-tier mapping.
+
+**Tech Stack:** Flask, SQLAlchemy, Flask-Migrate, slack-bolt (Python), Slack admin API (cookie-based), PostgreSQL
+
+**Spec:** `docs/superpowers/specs/2026-04-24-channel-sync-redesign-design.md`
+
+---
+
+### Task 1: Database Migration — Add `last_slack_activity` to SlackUser
+
+**Files:**
+- Modify: `app/models.py:107-126` (SlackUser model)
+- Create: `migrations/versions/xxxx_add_last_slack_activity.py` (via flask db migrate)
+
+- [ ] **Step 1: Add column to SlackUser model**
+
+In `app/models.py`, add the `last_slack_activity` column to the `SlackUser` class, after the `timezone` column (line 118):
+
+```python
+class SlackUser(db.Model):
+    __tablename__ = 'slack_users'
+
+    id = db.Column(db.Integer, primary_key=True)
+    slack_uid = db.Column(db.String(255), unique=True, nullable=False)
+    display_name = db.Column(db.String(255))
+    full_name = db.Column(db.String(255))
+    email = db.Column(db.String(255))
+    title = db.Column(db.String(255))
+    phone = db.Column(db.String(50))
+    status = db.Column(db.Text)
+    timezone = db.Column(db.String(100))
+    last_slack_activity = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # Relationship
+    user = db.relationship('User', backref='slack_user', uselist=False)
+
+    def __repr__(self):
+        return f'<SlackUser {self.slack_uid}>'
+```
+
+- [ ] **Step 2: Generate and review migration**
+
+Run:
+```bash
+source env/bin/activate
+flask db migrate -m "add last_slack_activity to slack_users"
+```
+
+Expected: A new migration file in `migrations/versions/`. Review it to confirm it adds a nullable DateTime column `last_slack_activity` to the `slack_users` table.
+
+- [ ] **Step 3: Apply migration**
+
+Run:
+```bash
+flask db upgrade
+```
+
+Expected: Migration applies successfully. Verify with:
+```bash
+docker exec tcsc-postgres psql -U tcsc -d tcsc_trips -c "\d slack_users" | grep last_slack_activity
+```
+
+Expected output includes: `last_slack_activity | timestamp without time zone |`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/models.py migrations/versions/*last_slack_activity*
+git commit -m "feat: add last_slack_activity column to SlackUser model"
+```
+
+---
+
+### Task 2: Activity Detection — `fetch_user_activity()` in admin_api.py
+
+**Files:**
+- Modify: `app/slack/admin_api.py` (add function after `invite_user_by_email`)
+- Test: `tests/slack/test_admin_api.py`
+
+- [ ] **Step 1: Write the test file**
+
+Create `tests/slack/test_admin_api.py`:
+
+```python
+"""Tests for admin API activity fetch."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestFetchUserActivity:
+    """Test fetch_user_activity admin API function."""
+
+    @patch('app.slack.admin_api.make_admin_request')
+    def test_returns_user_id_to_timestamp_map(self, mock_request):
+        from app.slack.admin_api import fetch_user_activity
+
+        mock_request.return_value = {
+            'ok': True,
+            'members': [
+                {
+                    'id': 'U123',
+                    'date_last_active': 1714000000,
+                },
+                {
+                    'id': 'U456',
+                    'date_last_active': 1713000000,
+                },
+            ],
+            'response_metadata': {'next_cursor': ''},
+        }
+
+        result = fetch_user_activity()
+
+        assert 'U123' in result
+        assert 'U456' in result
+        assert isinstance(result['U123'], datetime)
+        assert isinstance(result['U456'], datetime)
+
+    @patch('app.slack.admin_api.make_admin_request')
+    def test_skips_members_without_activity(self, mock_request):
+        from app.slack.admin_api import fetch_user_activity
+
+        mock_request.return_value = {
+            'ok': True,
+            'members': [
+                {
+                    'id': 'U123',
+                    'date_last_active': 1714000000,
+                },
+                {
+                    'id': 'U789',
+                    # no date_last_active
+                },
+            ],
+            'response_metadata': {'next_cursor': ''},
+        }
+
+        result = fetch_user_activity()
+
+        assert 'U123' in result
+        assert 'U789' not in result
+
+    @patch('app.slack.admin_api.make_admin_request')
+    def test_handles_pagination(self, mock_request):
+        from app.slack.admin_api import fetch_user_activity
+
+        mock_request.side_effect = [
+            {
+                'ok': True,
+                'members': [{'id': 'U1', 'date_last_active': 1714000000}],
+                'response_metadata': {'next_cursor': 'page2'},
+            },
+            {
+                'ok': True,
+                'members': [{'id': 'U2', 'date_last_active': 1714000000}],
+                'response_metadata': {'next_cursor': ''},
+            },
+        ]
+
+        result = fetch_user_activity()
+
+        assert len(result) == 2
+        assert 'U1' in result
+        assert 'U2' in result
+        assert mock_request.call_count == 2
+
+    @patch('app.slack.admin_api.make_admin_request')
+    def test_returns_empty_dict_on_api_error(self, mock_request):
+        from app.slack.admin_api import fetch_user_activity
+
+        mock_request.side_effect = Exception("API error")
+
+        result = fetch_user_activity()
+
+        assert result == {}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+pytest tests/slack/test_admin_api.py -v
+```
+
+Expected: FAIL — `fetch_user_activity` does not exist yet.
+
+- [ ] **Step 3: Implement `fetch_user_activity()`**
+
+Add to `app/slack/admin_api.py` after the `invite_user_by_email` function (after line 354):
+
+```python
+def fetch_user_activity() -> dict[str, datetime]:
+    """Fetch last-active timestamps for all workspace members.
+
+    Uses the Slack admin API (same cookie-based auth as role changes)
+    to retrieve the "Last active" data visible on the admin stats page.
+
+    Returns:
+        Dict mapping Slack user ID -> last active datetime.
+        Returns empty dict on failure (caller uses stale data).
+    """
+    from datetime import datetime
+
+    activity_map = {}
+    cursor = ''
+
+    try:
+        creds = get_admin_credentials()
+
+        while True:
+            data = {
+                'token': creds['token'],
+                'count': '200',
+                'include_deactivated_user_workspaces': 'false',
+            }
+            if cursor:
+                data['cursor'] = cursor
+
+            response = make_admin_request(
+                api_method='users.admin.list',
+                data=data,
+                action_description='Fetch user activity',
+                email='(bulk activity fetch)',
+            )
+
+            for member in response.get('members', []):
+                user_id = member.get('id')
+                last_active_ts = member.get('date_last_active')
+                if user_id and last_active_ts:
+                    activity_map[user_id] = datetime.utcfromtimestamp(last_active_ts)
+
+            next_cursor = response.get('response_metadata', {}).get('next_cursor', '')
+            if not next_cursor:
+                break
+            cursor = next_cursor
+
+        current_app.logger.info(f"Fetched activity for {len(activity_map)} Slack users")
+
+    except Exception as e:
+        current_app.logger.error(f"Failed to fetch user activity: {e}")
+
+    return activity_map
+```
+
+Also add the `datetime` import at the top of `admin_api.py` if not already present. Check line 1 — it currently imports `os`, `time`, `functools`, `requests`. Add `from datetime import datetime` after the existing imports:
+
+```python
+import os
+import time
+import functools
+import requests
+from datetime import datetime
+from typing import Optional
+from flask import current_app
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+pytest tests/slack/test_admin_api.py -v
+```
+
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/slack/admin_api.py tests/slack/test_admin_api.py
+git commit -m "feat: add fetch_user_activity() to admin API for activity-based tier checks"
+```
+
+---
+
+### Task 3: Update Tier Logic — `User.get_slack_tier()` with Activity Check
+
+**Files:**
+- Modify: `app/models.py:226-252` (User.get_slack_tier method)
+- Test: `tests/slack/test_tier_logic.py`
+
+- [ ] **Step 1: Write the tests**
+
+Create `tests/slack/test_tier_logic.py`:
+
+```python
+"""Tests for User.get_slack_tier() activity-based logic."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock, PropertyMock
+
+import pytest
+
+
+class FakeTag:
+    def __init__(self, name):
+        self.name = name
+
+
+class FakeSlackUser:
+    def __init__(self, last_slack_activity=None):
+        self.last_slack_activity = last_slack_activity
+
+
+class FakeUser:
+    """Minimal User stand-in that mirrors get_slack_tier logic."""
+    def __init__(self, status, seasons_since_active, tags=None, slack_user=None):
+        self.status = status
+        self.seasons_since_active = seasons_since_active
+        self.tags = tags or []
+        self.slack_user = slack_user
+
+
+def get_slack_tier_under_test(user, threshold_days=90):
+    """Call the real get_slack_tier after importing. We test the actual model method."""
+    # We'll test via the actual User model in integration,
+    # but for unit tests we replicate the logic to validate it.
+    # The implementation test verifies the model method matches.
+    full_member_tags = {'HEAD_COACH', 'ASSISTANT_COACH'}
+    if any(tag.name in full_member_tags for tag in user.tags):
+        return 'full_member'
+
+    if user.status == 'ACTIVE':
+        return 'full_member'
+    elif user.status == 'ALUMNI':
+        if user.seasons_since_active == 1:
+            return 'multi_channel_guest'
+        else:
+            if (user.slack_user
+                    and user.slack_user.last_slack_activity
+                    and (datetime.utcnow() - user.slack_user.last_slack_activity).days < threshold_days):
+                return 'multi_channel_guest'
+            return 'single_channel_guest'
+    return None
+
+
+class TestTierLogicActivity:
+    """Test activity-based tier for 2+ season alumni."""
+
+    def test_active_user_is_full_member(self):
+        user = FakeUser(status='ACTIVE', seasons_since_active=0)
+        assert get_slack_tier_under_test(user) == 'full_member'
+
+    def test_one_season_alumni_is_mcg(self):
+        user = FakeUser(status='ALUMNI', seasons_since_active=1)
+        assert get_slack_tier_under_test(user) == 'multi_channel_guest'
+
+    def test_two_season_alumni_no_activity_is_scg(self):
+        user = FakeUser(status='ALUMNI', seasons_since_active=2, slack_user=None)
+        assert get_slack_tier_under_test(user) == 'single_channel_guest'
+
+    def test_two_season_alumni_recent_activity_is_mcg(self):
+        slack_user = FakeSlackUser(last_slack_activity=datetime.utcnow() - timedelta(days=30))
+        user = FakeUser(status='ALUMNI', seasons_since_active=2, slack_user=slack_user)
+        assert get_slack_tier_under_test(user) == 'multi_channel_guest'
+
+    def test_two_season_alumni_old_activity_is_scg(self):
+        slack_user = FakeSlackUser(last_slack_activity=datetime.utcnow() - timedelta(days=120))
+        user = FakeUser(status='ALUMNI', seasons_since_active=2, slack_user=slack_user)
+        assert get_slack_tier_under_test(user) == 'single_channel_guest'
+
+    def test_two_season_alumni_activity_exactly_at_threshold_is_scg(self):
+        slack_user = FakeSlackUser(last_slack_activity=datetime.utcnow() - timedelta(days=90))
+        user = FakeUser(status='ALUMNI', seasons_since_active=2, slack_user=slack_user)
+        assert get_slack_tier_under_test(user) == 'single_channel_guest'
+
+    def test_two_season_alumni_activity_just_under_threshold_is_mcg(self):
+        slack_user = FakeSlackUser(last_slack_activity=datetime.utcnow() - timedelta(days=89))
+        user = FakeUser(status='ALUMNI', seasons_since_active=2, slack_user=slack_user)
+        assert get_slack_tier_under_test(user) == 'multi_channel_guest'
+
+    def test_three_season_alumni_recent_activity_is_mcg(self):
+        slack_user = FakeSlackUser(last_slack_activity=datetime.utcnow() - timedelta(days=10))
+        user = FakeUser(status='ALUMNI', seasons_since_active=3, slack_user=slack_user)
+        assert get_slack_tier_under_test(user) == 'multi_channel_guest'
+
+    def test_coach_override_trumps_everything(self):
+        slack_user = FakeSlackUser(last_slack_activity=datetime.utcnow() - timedelta(days=200))
+        user = FakeUser(status='ALUMNI', seasons_since_active=5, tags=[FakeTag('HEAD_COACH')], slack_user=slack_user)
+        assert get_slack_tier_under_test(user) == 'full_member'
+
+    def test_pending_user_returns_none(self):
+        user = FakeUser(status='PENDING', seasons_since_active=0)
+        assert get_slack_tier_under_test(user) is None
+
+    def test_dropped_user_returns_none(self):
+        user = FakeUser(status='DROPPED', seasons_since_active=0)
+        assert get_slack_tier_under_test(user) is None
+
+    def test_no_slack_user_linked_is_scg(self):
+        user = FakeUser(status='ALUMNI', seasons_since_active=2, slack_user=None)
+        assert get_slack_tier_under_test(user) == 'single_channel_guest'
+
+    def test_slack_user_with_null_activity_is_scg(self):
+        slack_user = FakeSlackUser(last_slack_activity=None)
+        user = FakeUser(status='ALUMNI', seasons_since_active=2, slack_user=slack_user)
+        assert get_slack_tier_under_test(user) == 'single_channel_guest'
+```
+
+- [ ] **Step 2: Run tests to verify they pass (testing the expected logic)**
+
+Run:
+```bash
+pytest tests/slack/test_tier_logic.py -v
+```
+
+Expected: All 13 tests PASS. These validate the target logic before we modify the model.
+
+- [ ] **Step 3: Update `User.get_slack_tier()` in models.py**
+
+Replace the `get_slack_tier` method at `app/models.py:226-252` with:
+
+```python
+    def get_slack_tier(self):
+        """Determine Slack membership tier based on status and activity.
+
+        Override rules (checked first):
+        - HEAD_COACH or ASSISTANT_COACH tags -> always full_member
+
+        Standard rules:
+        - ACTIVE status -> full_member
+        - ALUMNI with seasons_since_active == 1 -> multi_channel_guest
+        - ALUMNI with seasons_since_active >= 2 + active in last 90 days -> multi_channel_guest
+        - ALUMNI with seasons_since_active >= 2 + inactive 90+ days -> single_channel_guest
+        - PENDING or DROPPED -> None (no Slack automation)
+        """
+        full_member_tags = {'HEAD_COACH', 'ASSISTANT_COACH'}
+        if any(tag.name in full_member_tags for tag in self.tags):
+            return 'full_member'
+
+        if self.status == UserStatus.ACTIVE:
+            return 'full_member'
+        elif self.status == UserStatus.ALUMNI:
+            if self.seasons_since_active == 1:
+                return 'multi_channel_guest'
+            else:
+                if (self.slack_user
+                        and self.slack_user.last_slack_activity
+                        and (datetime.utcnow() - self.slack_user.last_slack_activity).days < 90):
+                    return 'multi_channel_guest'
+                return 'single_channel_guest'
+        return None
+```
+
+Note: `datetime` is already imported at the top of `models.py`.
+
+- [ ] **Step 4: Run tier logic tests again**
+
+Run:
+```bash
+pytest tests/slack/test_tier_logic.py -v
+```
+
+Expected: All 13 tests PASS.
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run:
+```bash
+pytest tests/ -v --tb=short
+```
+
+Expected: All existing tests pass. The only change is the `get_slack_tier` method, which now checks `self.slack_user.last_slack_activity` for 2+ season alumni. Existing tests that don't set up `slack_user` will still see `single_channel_guest` for 2+ alumni (same as before since `self.slack_user` will be `None`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/models.py tests/slack/test_tier_logic.py
+git commit -m "feat: add activity-based tier logic for 2+ season alumni"
+```
+
+---
+
+### Task 4: Update Channel Config — `slack_channels.yaml`
+
+**Files:**
+- Modify: `config/slack_channels.yaml`
+
+- [ ] **Step 1: Update the config file**
+
+Replace the entire contents of `config/slack_channels.yaml` with:
+
+```yaml
+# Slack Channel Sync Configuration
+# This config controls the automated channel membership sync job
+
+# Safety: Set to false only after validating dry-run logs
+dry_run: true  # DEFAULT: true - logs actions without making changes
+
+# Slack workspace settings
+slack:
+  workspace_domain: "twincitiesskiclub"
+  base_url: "https://twincitiesskiclub.slack.com/api/"
+
+# Channel configuration by membership tier
+# Maps User.get_slack_tier() return values to channel lists
+channels:
+  # ACTIVE users (seasons_since_active = 0) - full workspace access
+  full_member:
+    - "announcements-practices"
+    - "announcements-tcsc"
+    - "chat"
+    - "fresh-tracks"
+    - "gear-recs-swap"
+    - "races-information"
+    - "volunteer-and-job-opportunities"
+    - "extra-training-fun"
+    - "meme"
+    - "photos-videos"
+    - "race-waxing"
+
+  # ALUMNI (seasons_since_active = 1, or 2+ with recent activity/reactivated)
+  multi_channel_guest:
+    - "announcements-tcsc"
+    - "chat"
+    - "fresh-tracks"
+    - "gear-recs-swap"
+    - "races-information"
+    - "volunteer-and-job-opportunities"
+    - "extra-training-fun"
+    - "meme"
+    - "photos-videos"
+    - "race-waxing"
+
+  # ALUMNI (seasons_since_active >= 2, inactive 90+ days) - single-channel guest
+  single_channel_guest:
+    - "tcsc-reactivate-me"
+
+# Channels exclusive to full members (full_member - multi_channel_guest)
+exclusive_channels:
+  - "announcements-practices"
+
+# Activity-based tier check for 2+ season alumni
+# Alumni inactive longer than this threshold are demoted to SCG
+activity_threshold_days: 90
+
+# Channel for SCG reactivation workflow
+reactivation_channel: "tcsc-reactivate-me"
+reactivation_channel_id: "C0AUQCG7UB1"
+
+# Tags that mark users as exceptions (skipped by automation)
+# These users retain their current Slack status regardless of DB status
+# Note: HEAD_COACH and ASSISTANT_COACH are NOT exceptions - they get full_member tier override
+exception_tags:
+  - "BOARD_MEMBER"
+  - "ADMIN"
+  - "EXEMPT"
+
+# Welcome message for new member invitations
+invitation_message: "Welcome to the Twin Cities Ski Club Slack!"
+
+# ExpertVoice SFTP configuration
+# Members with ACTIVE status or ALUMNI (1 season) get ExpertVoice access
+expertvoice:
+  enabled: true
+  sftp:
+    host: "sftp.expertvoice.com"
+    port: 22
+    path: "/incoming/"
+    filename: "twincitiesskiclub.memberauth.csv"
+```
+
+Key changes from old config:
+- Removed `announcements-adventures` from `full_member` list
+- `single_channel_guest` changed from `announcements-tcsc` to `tcsc-reactivate-me`
+- `exclusive_channels` updated: removed `announcements-adventures`, only `announcements-practices` remains
+- Added `activity_threshold_days: 90`
+- Added `reactivation_channel` and `reactivation_channel_id`
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add config/slack_channels.yaml
+git commit -m "feat: update channel config for sync redesign
+
+- Remove announcements-adventures (will be archived)
+- SCG channel changes to tcsc-reactivate-me
+- Add activity_threshold_days and reactivation_channel config"
+```
+
+---
+
+### Task 5: Tier Transition Notifications
+
+**Files:**
+- Modify: `app/notifications/slack.py` (add new notification functions)
+- Test: `tests/slack/test_notifications.py`
+
+- [ ] **Step 1: Write the tests**
+
+Create `tests/slack/test_notifications.py`:
+
+```python
+"""Tests for tier transition notifications."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestSendTierTransitionNotification:
+
+    @patch('app.notifications.slack.requests.post')
+    @patch('app.notifications.slack.os.environ.get', return_value='https://hooks.slack.com/test')
+    def test_sends_demotion_notification(self, mock_env, mock_post):
+        from app.notifications.slack import send_tier_transition_notification
+
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        result = send_tier_transition_notification(
+            name='Jane Doe',
+            email='jane@example.com',
+            from_tier='multi_channel_guest',
+            to_tier='single_channel_guest',
+            reason='inactive 90+ days',
+        )
+
+        assert result is True
+        call_args = mock_post.call_args
+        payload = call_args[1]['json']
+        assert 'Jane Doe' in payload['text']
+        assert 'jane@example.com' in payload['text']
+        assert 'MCG → SCG' in payload['text']
+        assert 'inactive 90+ days' in payload['text']
+
+    @patch('app.notifications.slack.requests.post')
+    @patch('app.notifications.slack.os.environ.get', return_value='https://hooks.slack.com/test')
+    def test_sends_reactivation_notification(self, mock_env, mock_post):
+        from app.notifications.slack import send_tier_transition_notification
+
+        mock_post.return_value = MagicMock(status_code=200)
+        mock_post.return_value.raise_for_status = MagicMock()
+
+        result = send_tier_transition_notification(
+            name='Jane Doe',
+            email='jane@example.com',
+            from_tier='single_channel_guest',
+            to_tier='multi_channel_guest',
+            reason='self-service reactivation',
+        )
+
+        assert result is True
+        call_args = mock_post.call_args
+        payload = call_args[1]['json']
+        assert 'SCG → MCG' in payload['text']
+        assert 'self-service reactivation' in payload['text']
+
+    @patch('app.notifications.slack.os.environ.get', return_value=None)
+    def test_returns_false_when_no_webhook(self, mock_env):
+        from app.notifications.slack import send_tier_transition_notification
+
+        result = send_tier_transition_notification(
+            name='Jane Doe',
+            email='jane@example.com',
+            from_tier='full_member',
+            to_tier='multi_channel_guest',
+            reason='1 season not registered',
+        )
+
+        assert result is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+pytest tests/slack/test_notifications.py -v
+```
+
+Expected: FAIL — `send_tier_transition_notification` does not exist yet.
+
+- [ ] **Step 3: Implement `send_tier_transition_notification()`**
+
+Add to `app/notifications/slack.py` after the existing `send_payment_notification` function:
+
+```python
+TIER_DISPLAY = {
+    'full_member': 'Full Member',
+    'multi_channel_guest': 'MCG',
+    'single_channel_guest': 'SCG',
+}
+
+
+def send_tier_transition_notification(name, email, from_tier, to_tier, reason):
+    """Send Slack webhook notification for a tier transition."""
+    slack_webhook_url = os.environ.get('SLACK_WEBHOOK_URL')
+
+    if not slack_webhook_url:
+        current_app.logger.warning("SLACK_WEBHOOK_URL not configured, skipping tier notification")
+        return False
+
+    from_display = TIER_DISPLAY.get(from_tier, from_tier)
+    to_display = TIER_DISPLAY.get(to_tier, to_tier)
+
+    message = {
+        "text": (
+            f"Slack tier change: {name} ({email})\n"
+            f"{from_display} → {to_display}\n"
+            f"Reason: {reason}"
+        )
+    }
+
+    try:
+        response = requests.post(slack_webhook_url, json=message, timeout=5)
+        response.raise_for_status()
+        return True
+    except Exception as e:
+        current_app.logger.error(f"Failed to send tier transition notification: {e}")
+        return False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+pytest tests/slack/test_notifications.py -v
+```
+
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/notifications/slack.py tests/slack/test_notifications.py
+git commit -m "feat: add webhook notifications for tier transitions"
+```
+
+---
+
+### Task 6: Channel Sync Updates — Activity Integration & Private Channel Preservation
+
+**Files:**
+- Modify: `app/slack/channel_sync.py`
+- Test: `tests/slack/test_channel_sync.py`
+
+- [ ] **Step 1: Write the tests**
+
+Create `tests/slack/test_channel_sync.py`:
+
+```python
+"""Tests for channel sync private channel preservation and activity integration."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.slack.channel_sync import (
+    ChannelSyncResult,
+    get_managed_channel_ids,
+)
+
+
+class TestGetManagedChannelIds:
+    """Test helper that collects all managed channel IDs across tiers."""
+
+    def test_returns_union_of_all_tier_channels(self):
+        config = {
+            'channels': {
+                'full_member': ['ch-a', 'ch-b', 'ch-c'],
+                'multi_channel_guest': ['ch-a', 'ch-b'],
+                'single_channel_guest': ['ch-d'],
+            }
+        }
+        name_to_id = {
+            'ch-a': 'CA',
+            'ch-b': 'CB',
+            'ch-c': 'CC',
+            'ch-d': 'CD',
+        }
+
+        result = get_managed_channel_ids(config, name_to_id)
+
+        assert result == {'CA', 'CB', 'CC', 'CD'}
+
+    def test_skips_unknown_channels(self):
+        config = {
+            'channels': {
+                'full_member': ['ch-a', 'ch-missing'],
+                'multi_channel_guest': [],
+                'single_channel_guest': [],
+            }
+        }
+        name_to_id = {'ch-a': 'CA'}
+
+        result = get_managed_channel_ids(config, name_to_id)
+
+        assert result == {'CA'}
+
+
+class TestPrivateChannelPreservation:
+    """Test that MCG transitions preserve unmanaged private channels."""
+
+    def test_merge_preserves_private_channels(self):
+        """Verify the merge logic that will be used in sync_single_user."""
+        managed_ids = {'C_ANN', 'C_CHAT', 'C_GEAR'}
+        target_mcg_ids = {'C_ANN', 'C_CHAT', 'C_GEAR'}
+        current_user_channels = {'C_ANN', 'C_CHAT', 'C_GEAR', 'C_BOOKCLUB', 'C_SOCCER'}
+
+        private_to_preserve = current_user_channels - managed_ids
+        merged = target_mcg_ids | private_to_preserve
+
+        assert 'C_BOOKCLUB' in merged
+        assert 'C_SOCCER' in merged
+        assert len(merged) == 5
+
+    def test_merge_with_no_private_channels(self):
+        managed_ids = {'C_ANN', 'C_CHAT'}
+        target_mcg_ids = {'C_ANN', 'C_CHAT'}
+        current_user_channels = {'C_ANN', 'C_CHAT'}
+
+        private_to_preserve = current_user_channels - managed_ids
+        merged = target_mcg_ids | private_to_preserve
+
+        assert merged == target_mcg_ids
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+```bash
+pytest tests/slack/test_channel_sync.py -v
+```
+
+Expected: FAIL — `get_managed_channel_ids` does not exist yet.
+
+- [ ] **Step 3: Add `get_managed_channel_ids` helper to channel_sync.py**
+
+Add after the `get_target_channel_ids` function (after line 230 in `app/slack/channel_sync.py`):
+
+```python
+def get_managed_channel_ids(
+    config: dict,
+    channel_name_to_id: dict[str, str]
+) -> set[str]:
+    """Get all channel IDs managed by the sync across all tiers.
+
+    Used to distinguish managed channels from private/community channels
+    that users joined manually (and should be preserved during transitions).
+    """
+    all_managed = set()
+    for tier in ['full_member', 'multi_channel_guest', 'single_channel_guest']:
+        for name in config.get('channels', {}).get(tier, []):
+            channel_id = channel_name_to_id.get(name)
+            if channel_id:
+                all_managed.add(channel_id)
+    return all_managed
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+pytest tests/slack/test_channel_sync.py -v
+```
+
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Update `sync_single_user()` for private channel preservation on MCG transitions**
+
+In `app/slack/channel_sync.py`, modify `sync_single_user()`. The function signature gains a new parameter `managed_channel_ids`. Find the block at lines 384-395 where MCG/SCG role changes are handled:
+
+```python
+            # For MCG/SCG, role change also sets channels
+            if target_tier in ('multi_channel_guest', 'single_channel_guest'):
+                change_user_role(
+                    user_id=user_id,
+                    email=email,
+                    target_role=target_role,
+                    team_id=team_id,
+                    dry_run=dry_run,
+                    channel_ids=list(target_channel_ids)
+                )
+                result.role_changes += 1
+                return  # MCG/SCG role change handles channels
+```
+
+Replace with:
+
+```python
+            if target_tier == 'multi_channel_guest':
+                channels_for_role = set(target_channel_ids)
+                private_preserved = current_channels - managed_channel_ids
+                if private_preserved:
+                    channels_for_role |= private_preserved
+                    preserve_names = [channel_id_to_properties.get(cid, {}).get('name', cid) for cid in private_preserved]
+                    result.traces.append(f"PRESERVE_PRIVATE: {email} | keeping {preserve_names}")
+                change_user_role(
+                    user_id=user_id,
+                    email=email,
+                    target_role=target_role,
+                    team_id=team_id,
+                    dry_run=dry_run,
+                    channel_ids=list(channels_for_role)
+                )
+                result.role_changes += 1
+                return
+
+            elif target_tier == 'single_channel_guest':
+                change_user_role(
+                    user_id=user_id,
+                    email=email,
+                    target_role=target_role,
+                    team_id=team_id,
+                    dry_run=dry_run,
+                    channel_ids=list(target_channel_ids)
+                )
+                result.role_changes += 1
+                return
+```
+
+- [ ] **Step 6: Update `sync_single_user()` function signature**
+
+Add `managed_channel_ids: set[str]` parameter to `sync_single_user()`:
+
+Change line 291:
+```python
+def sync_single_user(
+    slack_user: dict,
+    target_tier: str,
+    target_channel_ids: set[str],
+    full_member_channel_ids: set[str],
+    managed_channel_ids: set[str],
+    channel_id_to_properties: dict[str, dict],
+    team_id: str,
+    dry_run: bool,
+    result: ChannelSyncResult
+) -> None:
+```
+
+- [ ] **Step 7: Update `run_channel_sync()` to compute and pass managed IDs, and integrate activity fetch**
+
+In `app/slack/channel_sync.py`, add the import at the top:
+
+```python
+from app.slack.admin_api import (
+    ROLE_FULL_MEMBER,
+    ROLE_MCG,
+    ROLE_SCG,
+    change_user_role,
+    invite_user_by_email,
+    validate_admin_credentials,
+    CookieExpiredError,
+    AdminAPIError,
+    fetch_user_activity,
+)
+```
+
+Then in `run_channel_sync()`, after the `tier_channel_ids` computation (after line 592), add:
+
+```python
+        # Compute all managed channel IDs (for private channel preservation)
+        managed_channel_ids = get_managed_channel_ids(config, channel_name_to_id)
+
+        # Fetch activity data and update SlackUser records
+        from app.models import SlackUser
+        activity_map = fetch_user_activity()
+        if activity_map:
+            for slack_user_record in SlackUser.query.all():
+                if slack_user_record.slack_uid in activity_map:
+                    slack_user_record.last_slack_activity = activity_map[slack_user_record.slack_uid]
+            db.session.commit()
+            current_app.logger.info(f"Updated last_slack_activity for {len(activity_map)} users")
+        else:
+            current_app.logger.warning("Activity fetch returned no data — using stale last_slack_activity values")
+```
+
+And update the `sync_single_user` call (around line 624) to pass `managed_channel_ids`:
+
+```python
+            sync_single_user(
+                slack_user=slack_user,
+                target_tier=target_tier,
+                target_channel_ids=target_channel_ids,
+                full_member_channel_ids=tier_channel_ids['full_member'],
+                managed_channel_ids=managed_channel_ids,
+                channel_id_to_properties=channel_id_to_properties,
+                team_id=team_id,
+                dry_run=dry_run,
+                result=result
+            )
+```
+
+- [ ] **Step 8: Add tier transition notification calls to sync_single_user**
+
+In `sync_single_user()`, add import and notification calls. At the top of `channel_sync.py`, add:
+
+```python
+from app.notifications.slack import send_tier_transition_notification
+```
+
+Then inside `sync_single_user()`, after each role change trace/log block, add notification calls. After the `result.role_changes += 1` for the MCG block (the one you just wrote):
+
+```python
+                send_tier_transition_notification(
+                    name=db_user.full_name if db_user else email,
+                    email=email,
+                    from_tier=current_role,
+                    to_tier='multi_channel_guest',
+                    reason='activity-based or 1-season alumni',
+                )
+```
+
+After the `result.role_changes += 1` for the SCG block:
+
+```python
+                send_tier_transition_notification(
+                    name=db_user.full_name if db_user else email,
+                    email=email,
+                    from_tier=current_role,
+                    to_tier='single_channel_guest',
+                    reason='inactive 90+ days',
+                )
+```
+
+After the full_member role change `result.role_changes += 1` (the existing one for full_member promotion):
+
+```python
+                send_tier_transition_notification(
+                    name=db_user.full_name if db_user else email,
+                    email=email,
+                    from_tier=current_role,
+                    to_tier='full_member',
+                    reason='active member or re-registration',
+                )
+```
+
+- [ ] **Step 9: Run all tests**
+
+Run:
+```bash
+pytest tests/ -v --tb=short
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add app/slack/channel_sync.py tests/slack/test_channel_sync.py
+git commit -m "feat: add activity fetch integration and private channel preservation to channel sync"
+```
+
+---
+
+### Task 7: Reactivation Custom Step — Bolt Handler
+
+**Files:**
+- Modify: `app/slack/bolt_app.py` (add function handler before the `else` block at line 1340)
+- Test: `tests/slack/test_reactivation.py`
+
+- [ ] **Step 1: Write the tests**
+
+Create `tests/slack/test_reactivation.py`:
+
+```python
+"""Tests for the reactivation custom step handler logic."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class FakeSlackUser:
+    def __init__(self, slack_uid):
+        self.slack_uid = slack_uid
+        self.id = 1
+
+
+class FakeUser:
+    def __init__(self, status='ALUMNI', seasons_since_active=2, email='test@example.com',
+                 first_name='Jane', last_name='Doe', slack_user=None):
+        self.status = status
+        self.seasons_since_active = seasons_since_active
+        self.email = email
+        self.first_name = first_name
+        self.last_name = last_name
+        self.slack_user = slack_user
+
+    @property
+    def full_name(self):
+        return f"{self.first_name} {self.last_name}"
+
+
+def validate_reactivation(user):
+    """Replicate validation logic from the handler for unit testing."""
+    if not user:
+        return False, "No linked account found"
+    if user.status != 'ALUMNI' or user.seasons_since_active < 2:
+        return False, "Not eligible for reactivation"
+    return True, None
+
+
+class TestReactivationValidation:
+
+    def test_valid_alumni_2_seasons(self):
+        user = FakeUser(status='ALUMNI', seasons_since_active=2)
+        valid, error = validate_reactivation(user)
+        assert valid is True
+        assert error is None
+
+    def test_valid_alumni_3_seasons(self):
+        user = FakeUser(status='ALUMNI', seasons_since_active=3)
+        valid, error = validate_reactivation(user)
+        assert valid is True
+
+    def test_rejects_active_user(self):
+        user = FakeUser(status='ACTIVE', seasons_since_active=0)
+        valid, error = validate_reactivation(user)
+        assert valid is False
+        assert 'Not eligible' in error
+
+    def test_rejects_1_season_alumni(self):
+        user = FakeUser(status='ALUMNI', seasons_since_active=1)
+        valid, error = validate_reactivation(user)
+        assert valid is False
+
+    def test_rejects_none_user(self):
+        valid, error = validate_reactivation(None)
+        assert valid is False
+        assert 'No linked account' in error
+
+    def test_rejects_pending_user(self):
+        user = FakeUser(status='PENDING', seasons_since_active=0)
+        valid, error = validate_reactivation(user)
+        assert valid is False
+```
+
+- [ ] **Step 2: Run tests to verify they pass (validation logic)**
+
+Run:
+```bash
+pytest tests/slack/test_reactivation.py -v
+```
+
+Expected: All 6 tests PASS.
+
+- [ ] **Step 3: Add the Bolt custom function handler**
+
+In `app/slack/bolt_app.py`, add the following BEFORE the `@bolt_app.event("message")` handler (before line 1335). This goes in the `if _bot_token:` block:
+
+```python
+    # =========================================================================
+    # Custom Functions (Workflow Builder Custom Steps)
+    # =========================================================================
+
+    @bolt_app.function("reactivate_membership")
+    def handle_reactivate_membership(inputs, complete, fail, logger):
+        """Handle reactivation workflow custom step.
+
+        Triggered by Workflow Builder when an SCG user clicks the
+        reactivation workflow in #tcsc-reactivate-me.
+        """
+        user_id = inputs.get("user_id")
+        if not user_id:
+            fail("No user_id provided")
+            return
+
+        logger.info(f"Reactivation request from {user_id}")
+
+        with get_app_context():
+            from app.models import User, SlackUser, db
+            from app.slack.channel_sync import load_channel_config, get_target_channel_ids
+            from app.slack.client import get_team_id, get_channel_maps
+            from app.slack.admin_api import change_user_role, ROLE_MCG
+            from app.notifications.slack import send_tier_transition_notification
+
+            slack_user = SlackUser.query.filter_by(slack_uid=user_id).first()
+            if not slack_user or not slack_user.user:
+                fail("No linked TCSC account found for your Slack user. Please contact an admin.")
+                return
+
+            user = slack_user.user
+
+            if user.status != 'ALUMNI' or user.seasons_since_active < 2:
+                fail("Your account is not eligible for reactivation. You may already have full access.")
+                return
+
+            try:
+                config = load_channel_config()
+                channel_name_to_id, _ = get_channel_maps()
+                team_id = get_team_id()
+
+                mcg_channel_names = config.get('channels', {}).get('multi_channel_guest', [])
+                mcg_channel_ids = []
+                for name in mcg_channel_names:
+                    cid = channel_name_to_id.get(name)
+                    if cid:
+                        mcg_channel_ids.append(cid)
+
+                change_user_role(
+                    user_id=user_id,
+                    email=user.email,
+                    target_role=ROLE_MCG,
+                    team_id=team_id,
+                    dry_run=False,
+                    channel_ids=mcg_channel_ids,
+                )
+
+                send_tier_transition_notification(
+                    name=user.full_name,
+                    email=user.email,
+                    from_tier='single_channel_guest',
+                    to_tier='multi_channel_guest',
+                    reason='self-service reactivation',
+                )
+
+                logger.info(f"Reactivated {user.email} from SCG to MCG")
+                complete(outputs={})
+
+            except Exception as e:
+                logger.error(f"Reactivation failed for {user.email}: {e}")
+                fail(f"Reactivation failed. Please try again or contact an admin.")
+```
+
+Note: The `get_app_context()` helper is already defined in `bolt_app.py` — it provides a Flask app context for database operations inside Bolt handlers. Verify it exists by checking for `def get_app_context` in the file.
+
+- [ ] **Step 4: Verify `get_app_context` exists in bolt_app.py**
+
+Run:
+```bash
+grep -n "def get_app_context" app/slack/bolt_app.py
+```
+
+Expected: A line showing the helper function definition. If it doesn't exist, check for the pattern used by other handlers (like `handle_rsvp_action`) that access the database — they use `with get_app_context():` or a similar pattern.
+
+- [ ] **Step 5: Run full test suite**
+
+Run:
+```bash
+pytest tests/ -v --tb=short
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/slack/bolt_app.py tests/slack/test_reactivation.py
+git commit -m "feat: add reactivate_membership custom step handler for Workflow Builder"
+```
+
+---
+
+### Task 8: Slack App Manifest & Workflow Configuration
+
+This task documents the manual steps needed in the Slack admin UI. No code changes.
+
+- [ ] **Step 1: Update Slack app manifest**
+
+Go to https://api.slack.com/apps → select the TCSC app → App Manifest. Add the following:
+
+Under `settings.event_subscriptions.bot_events`, add:
+```
+- function_executed
+```
+
+Under `settings`, add:
+```yaml
+org_deploy_enabled: true
+function_runtime: remote
+```
+
+Under the top-level `functions` key, add:
+```yaml
+functions:
+  reactivate_membership:
+    title: "Reactivate Membership"
+    description: "Promotes an inactive alumni from SCG to MCG"
+    input_parameters:
+      user_id:
+        type: "slack#/types/user_id"
+        title: "User"
+        description: "The person who triggered the workflow"
+        is_required: true
+    output_parameters: {}
+```
+
+- [ ] **Step 2: Configure the workflow in Workflow Builder**
+
+In Slack, open the existing workflow in `#tcsc-reactivate-me`:
+1. Add a new step → search for the TCSC app → select "Reactivate Membership"
+2. Map the "Person who used this workflow" variable to the `user_id` input
+3. Save and publish the workflow
+
+- [ ] **Step 3: Archive `announcements-adventures`**
+
+In Slack, go to `#announcements-adventures` → Channel settings → Archive this channel.
+
+- [ ] **Step 4: Add the bot to community private channels**
+
+Notify channel owners of private community channels (book club, soccer, etc.) to add the TCSC bot so that MCG transitions preserve membership.
+
+---
+
+### Task 9: Dry-Run Validation
+
+**Files:** None (operational validation)
+
+- [ ] **Step 1: Run sync in dry-run mode**
+
+Ensure `dry_run: true` is set in `config/slack_channels.yaml` (it is by default). Then trigger a manual sync from the admin UI at `/admin/channel-sync` or via the Flask shell:
+
+```bash
+flask shell
+>>> from app.slack.channel_sync import run_channel_sync
+>>> result = run_channel_sync(dry_run=True)
+>>> print(result.to_dict())
+```
+
+- [ ] **Step 2: Review dry-run traces**
+
+Check the `result.traces` list for expected behavior:
+- 2+ season alumni with recent activity should show as MCG (not SCG)
+- 2+ season alumni without recent activity should show as SCG
+- Private channel preservation traces (`PRESERVE_PRIVATE`) should appear for MCG transitions
+- The SCG channel should be `tcsc-reactivate-me`, not `announcements-tcsc`
+- `announcements-adventures` should not appear in any channel operations
+
+- [ ] **Step 3: Validate activity data was fetched**
+
+Check `SlackUser.last_slack_activity` values:
+
+```bash
+flask shell
+>>> from app.models import SlackUser
+>>> users_with_activity = SlackUser.query.filter(SlackUser.last_slack_activity.isnot(None)).count()
+>>> print(f"Users with activity data: {users_with_activity}")
+>>> # Spot-check a few
+>>> for su in SlackUser.query.filter(SlackUser.last_slack_activity.isnot(None)).limit(5):
+...     print(f"{su.email}: {su.last_slack_activity}")
+```
+
+- [ ] **Step 4: Switch to live mode when validated**
+
+After reviewing dry-run results, update `config/slack_channels.yaml`:
+```yaml
+dry_run: false
+```
+
+Commit and deploy:
+```bash
+git add config/slack_channels.yaml
+git commit -m "chore: switch channel sync to live mode after dry-run validation"
+```

--- a/docs/superpowers/specs/2026-04-24-channel-sync-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-24-channel-sync-redesign-design.md
@@ -1,0 +1,202 @@
+# Channel Sync Redesign
+
+**Date:** 2026-04-24
+**Status:** Draft
+**Stakeholders:** Rob, Alex Gude, Augie Witkowski, Ellie Thorsgaard
+
+## Problem
+
+The current Slack channel sync system uses a simple time-based tier model: ACTIVE members get full access, 1-season alumni become multi-channel guests (MCG), and 2+ season alumni become single-channel guests (SCG). This creates two issues:
+
+1. **Engaged alumni lose access** — A 2+ season alumni who is actively using Slack (chatting in book club, participating in community channels) gets demoted to SCG with one channel. This hurts community retention.
+2. **Channel structure is confusing** — `announcements-adventures` vs `announcements-tcsc` is unclear. Trip, apparel, and adventure content is split across channels with no obvious distinction.
+3. **No path back** — Once demoted to SCG, alumni have no self-service way to regain access. They need manual admin intervention.
+4. **250 paid seat limit** — Currently 223/250. All MCGs count as paid seats. We need a mechanism to keep the MCG pool limited to people who are actually engaged.
+
+## Design
+
+### Channel Structure
+
+Archive `announcements-adventures`. Restructure announcement channels by audience:
+
+| Channel | Audience | Content | Posting permissions |
+|---|---|---|---|
+| `announcements-tcsc` | full_member + MCG | Trips, adventures, apparel, seasonal info, club news | Board members only |
+| `announcements-practices` | full_member only | Practice schedules, workouts, RSVPs | Board/coaches |
+| `tcsc-reactivate-me` (C0AUQCG7UB1) | SCG only + Rob + president | Reactivation workflow | Board only (SCGs interact via workflow) |
+
+Community channels (chat, gear-recs-swap, extra-training-fun, races-information, meme, photos-videos, race-waxing, fresh-tracks, volunteer-and-job-opportunities) remain unchanged — available to full_member and MCG tiers.
+
+**Full channel-to-tier mapping:**
+
+| Channel | full_member | MCG | SCG |
+|---|---|---|---|
+| `announcements-tcsc` | yes | yes | no |
+| `announcements-practices` | yes | no | no |
+| `chat` | yes | yes | no |
+| `fresh-tracks` | yes | yes | no |
+| `gear-recs-swap` | yes | yes | no |
+| `races-information` | yes | yes | no |
+| `volunteer-and-job-opportunities` | yes | yes | no |
+| `extra-training-fun` | yes | yes | no |
+| `meme` | yes | yes | no |
+| `photos-videos` | yes | yes | no |
+| `race-waxing` | yes | yes | no |
+| `tcsc-reactivate-me` | no | no | yes |
+
+### Tier Logic
+
+Updated `User.get_slack_tier()` rules:
+
+```
+Coach override (HEAD_COACH, ASSISTANT_COACH tags) → full_member
+ACTIVE status → full_member
+ALUMNI + seasons_since_active == 1 → multi_channel_guest
+ALUMNI + seasons_since_active >= 2 + last_slack_activity within 90 days → multi_channel_guest
+ALUMNI + seasons_since_active >= 2 + last_slack_activity older than 90 days → single_channel_guest
+PENDING / DROPPED → None (no Slack automation)
+```
+
+Three paths to MCG for 2+ season alumni:
+1. **Still active on Slack** — `last_slack_activity` within 90 days, stays MCG automatically
+2. **Self-service reactivation** — SCG clicks workflow in `tcsc-reactivate-me`, promoted to MCG
+3. **Re-registers for a season** — becomes ACTIVE/full_member via normal registration flow
+
+Demotion cycle: any MCG whose `last_slack_activity` exceeds 90 days is demoted to SCG during the daily sync. This includes previously-reactivated users who went quiet again.
+
+### Activity Detection
+
+**Data source:** Slack admin API at `twincitiesskiclub.slack.com/admin/stats#members` — the "Last active" column. Accessed via the existing cookie-based admin API auth in `admin_api.py`.
+
+**New function:** `fetch_user_activity()` in `admin_api.py` — calls the admin endpoint that powers the stats page, returns a map of `{slack_user_id: last_active_timestamp}`. The exact admin API endpoint (likely `users.admin.list` or a stats-specific endpoint) needs to be discovered during implementation by inspecting the network requests on the admin stats page.
+
+**Storage:** New `last_slack_activity` column (DateTime, nullable) on the `SlackUser` model. Updated during each sync run.
+
+**Integration:** The existing 3am daily `run_channel_sync()` job gets an additional early step:
+1. Call `fetch_user_activity()` → get activity map
+2. Update `SlackUser.last_slack_activity` for each matched user
+3. Proceed with existing sync logic — `get_slack_tier()` now uses the updated activity data
+
+**90-day threshold:** Configurable via `activity_threshold_days` in `config/slack_channels.yaml`. Default: 90.
+
+**Failure handling:** If the admin API activity fetch fails (cookies expired, network error), the sync continues using the last-stored `last_slack_activity` values. No mass demotions on transient failures. A warning is logged.
+
+### Reactivation Workflow
+
+**Mechanism:** Slack Custom Steps (Custom Functions) via Bolt.
+
+**Slack App Manifest changes:**
+- Add `function_executed` to bot event subscriptions
+- Set `org_deploy_enabled: true` and `function_runtime: remote`
+- Define `reactivate_membership` function with `user_id` input parameter (type `slack#/types/user_id`)
+
+**Bolt handler:** New `@bolt_app.function("reactivate_membership")` handler in `bolt_app.py`:
+1. Receives triggering user's Slack ID via `inputs["user_id"]`
+2. Looks up user by Slack ID → finds linked `User` record
+3. Validates they are currently SCG and 2+ season alumni
+4. Calls `change_user_role()` to promote SCG → MCG with standard MCG channel list
+5. Sends webhook notification to registration team channel
+6. Calls `complete()` to signal success back to the workflow
+
+**Workflow Builder setup** (manual, done by Rob):
+- Add the app's "Reactivate Membership" custom step to the existing workflow in `tcsc-reactivate-me`
+- Map "Person who used this workflow" → `user_id` input parameter
+
+### Private Channel Preservation
+
+When transitioning full_member → MCG, private channel memberships should be preserved (e.g., book club, soccer team, Lake Placid).
+
+**Prerequisite:** The bot must be a member of any private channel it needs to detect. Channel owners opt in by adding the bot — no centralized config list needed.
+
+**Sync logic change** in `sync_single_user()`:
+1. Before calling `change_user_role()` for MCG, fetch the user's current channels via `get_user_channels()` (already queries both public and private channels)
+2. Identify channels not in the managed config (these are the private/community channels to preserve)
+3. Merge those channel IDs into the MCG channel list
+4. Pass the combined list to `change_user_role()`
+
+When transitioning MCG → SCG, no preservation — they lose all channels and get only `tcsc-reactivate-me`.
+
+### Logging & Notifications
+
+Webhook notifications sent to the registration team channel for tier transitions:
+- **Demotion:** "Jane Doe (jane@example.com) demoted MCG → SCG — inactive 90+ days"
+- **Reactivation:** "Jane Doe reactivated their account (SCG → MCG)"
+- **Role change:** "Jane Doe transitioned full_member → MCG (1 season not registered)"
+
+Uses the existing `SLACK_WEBHOOK_URL` pattern from `app/notifications/slack.py`. The webhook URL may point to the same channel as payment notifications or a separate registration-team channel — to be configured via environment variable or `slack_channels.yaml`.
+
+### Config Changes
+
+**`config/slack_channels.yaml` updates:**
+
+```yaml
+channels:
+  full_member:
+    - "announcements-tcsc"
+    - "announcements-practices"
+    - "chat"
+    - "fresh-tracks"
+    - "gear-recs-swap"
+    - "races-information"
+    - "volunteer-and-job-opportunities"
+    - "extra-training-fun"
+    - "meme"
+    - "photos-videos"
+    - "race-waxing"
+
+  multi_channel_guest:
+    - "announcements-tcsc"
+    - "chat"
+    - "fresh-tracks"
+    - "gear-recs-swap"
+    - "races-information"
+    - "volunteer-and-job-opportunities"
+    - "extra-training-fun"
+    - "meme"
+    - "photos-videos"
+    - "race-waxing"
+
+  single_channel_guest:
+    - "tcsc-reactivate-me"
+
+# Activity-based tier check for 2+ season alumni
+activity_threshold_days: 90
+
+# Channel for SCG reactivation workflow
+reactivation_channel: "tcsc-reactivate-me"
+reactivation_channel_id: "C0AUQCG7UB1"
+```
+
+### Migration Plan
+
+**One-time admin steps:**
+1. Create `tcsc-reactivate-me` channel (done — C0AUQCG7UB1)
+2. Archive `announcements-adventures`
+3. Confirm `announcements-tcsc` posting permissions are board-only
+4. Add the bot to any private community channels that should preserve MCG membership
+5. Update Slack app manifest (function_executed event, function definition)
+6. Configure workflow in Workflow Builder to use the custom step
+
+**Code deployment order:**
+1. Database migration: add `last_slack_activity` column to `slack_users` table
+2. `admin_api.py`: add `fetch_user_activity()` function
+3. `models.py`: add `last_slack_activity` to `SlackUser`, update `User.get_slack_tier()` with activity logic
+4. `slack_channels.yaml`: update channel config
+5. `channel_sync.py`: update `sync_single_user()` with private channel preservation and activity fetch integration
+6. `bolt_app.py`: add `@bolt_app.function("reactivate_membership")` handler
+7. `notifications/slack.py`: add tier transition notification functions
+8. Deploy and run first sync in dry-run mode to validate
+
+**Rollback:** Revert `slack_channels.yaml` to the old config and the sync reverts to current behavior. The `last_slack_activity` column and reactivation handler are additive and don't break anything if the config is rolled back.
+
+### Edge Cases
+
+- **Cookie expiry during activity fetch:** Sync continues with stale `last_slack_activity` data. No demotions from missing data. Warning logged.
+- **User not in database:** Treated as SCG (existing behavior, unchanged).
+- **Reactivation when near 250 seat limit:** Reactivation proceeds (Slack handles billing). Current paid seat count logged in webhook notification for visibility.
+- **User reactivates then goes quiet again:** The 90-day inactivity check applies uniformly. They get demoted back to SCG and can reactivate again.
+- **Bot not in a private channel:** User loses access to that private channel on full_member → MCG transition. Channel owners can re-invite, or add the bot to preserve future transitions.
+- **1-season alumni with private channels:** MCG tier is automatic. Private channels are preserved via the same merge logic as full_member → MCG transitions.
+- **Multiple seasons skipped at once:** `seasons_since_active` jumps from 0 to 2+ on season activation. Activity check applies immediately.
+- **Coach tag override:** Coaches always get full_member regardless of registration status or activity. Unchanged.
+- **SCG tries to reactivate but isn't 2+ season alumni:** Handler validates status and rejects with a message. Guards against misuse if a non-SCG user somehow accesses the workflow.


### PR DESCRIPTION
## Summary
- The `/api/is_returning_member` endpoint now returns `new_registration_open` when the email isn't a returning member
- Frontend disables the register button and shows a warning if new member registration isn't open yet
- Existing server-side POST validation remains as the backstop

## Test plan
- [ ] Set season with returning window open but new window not yet open
- [ ] Enter a non-returning email — verify warning appears and button is disabled
- [ ] Enter a returning email — verify button is enabled
- [ ] Change from returning to non-returning email — verify button disables again

🤖 Generated with [Claude Code](https://claude.com/claude-code)