### PR TITLE
fix: scope new-member email check to the form's season

### DIFF
--- a/app/routes/registration.py
+++ b/app/routes/registration.py
@@ -217,6 +217,12 @@ def api_is_returning_member():
     is_returning = bool(user and getattr(user, 'is_returning', False))
     result = {'is_returning': is_returning}
     if not is_returning:
-        season = Season.get_current()
+        season = None
+        season_id = data.get('season_id')
+        if season_id is not None:
+            try:
+                season = Season.query.get(int(season_id))
+            except (TypeError, ValueError):
+                season = None
         result['new_registration_open'] = bool(season and season.is_new_open())
     return jsonify(result)

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -292,11 +292,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const newMemberRadio = document.querySelector('input[name="status"][value="new"]');
       const returningRadio = document.querySelector('input[name="status"][value="returning_former"]');
 
+      const seasonId = emailInput.closest('form')?.dataset.seasonId;
+
       try {
         const resp = await fetch('/api/is_returning_member', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email })
+          body: JSON.stringify({ email, season_id: seasonId })
         });
         const data = await resp.json();
         if (data.is_returning) {


### PR DESCRIPTION
## Summary
- `/api/is_returning_member` was always asking `Season.get_current()` whether new-member registration was open, regardless of which season's page the user was on.
- When a new season has its registration window open but `is_current` is still on the prior (closed) season, every fresh email entered on the new-season page gets the misleading "Registration for new members is not yet open" message and the submit button is disabled.
- Frontend now sends the form's `data-season-id` along with the email; backend looks up that specific season for the open-window check. Falls back to no season (and thus `new_registration_open: false`) if `season_id` is missing or invalid.

## Test plan
- [ ] Open the registration page for a season whose new-member window is currently open but is **not** marked `is_current`. Enter a brand-new email and confirm the email-blur message no longer warns "not yet open" and the submit button stays enabled.
- [ ] Open the same page when the new-member window is in the **future**. Confirm the warning still appears and the submit button is disabled.
- [ ] Enter a returning-member email and confirm the success path is unchanged.