### PR TITLE
fix: friendlier email-check copy on registration form

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -308,13 +308,13 @@ document.addEventListener('DOMContentLoaded', () => {
           const submitBtn = document.getElementById('register-btn');
           if (submitBtn) submitBtn.disabled = false;
         } else if (data.new_registration_open === false) {
-          emailStatusMsg.textContent = '⚠️ Registration for new members is not yet open. Please check back when the new member registration window begins.';
+          emailStatusMsg.textContent = '⚠️ Registration for new members isn\'t currently open. Please check back when the new member registration window opens.';
           emailStatusMsg.style.color = '#b07b2c';
           const submitBtn = document.getElementById('register-btn');
           if (submitBtn) submitBtn.disabled = true;
         } else {
-          emailStatusMsg.textContent = '⚠️ We couldn\'t find your email in our returning member records. Please register as a new member or try a different email address if you believe this is a mistake.';
-          emailStatusMsg.style.color = '#b07b2c';
+          emailStatusMsg.textContent = '👋 Looks like you\'re new here. We\'ll register you as a new member. If you think you\'ve registered before, try a different email.';
+          emailStatusMsg.style.color = '#3730a3';
           if (newMemberRadio) newMemberRadio.checked = true;
         }
       } catch (err) {


### PR DESCRIPTION
## Summary
- The "we couldn't find your email" message led with a warning emoji and amber color, even though for a brand-new member it's the expected and correct path. Reworded as a welcoming "Looks like you're new here" note in info-indigo.
- The closed-window message used to say "is not yet open" — misleading after the window has already closed. Now reads "isn't currently open" so it's accurate in both directions.

## Test plan
- [ ] On a season with new-member registration open, enter a brand-new email. Confirm the message is welcoming (👋, info-indigo) and the new-member radio is selected.
- [ ] On a season whose new-member window is in the future or has already closed, confirm the warning still appears in amber and the submit button is disabled.
- [ ] Enter a returning-member email and confirm the success path is unchanged.