### PR TITLE
Fix production practice migration recovery

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -74,11 +74,10 @@ def create_app(environment=None):
     # Register template filters
     register_template_filters(app)
 
-    with app.app_context():
-        db.create_all()
-
-    # Initialize background scheduler for channel sync jobs
-    init_scheduler(app)
+    # Schema changes belong exclusively to Alembic. Migration commands still
+    # need the Flask-Migrate extension, but must not start background workers.
+    if os.getenv("TCSC_MIGRATION_ONLY") != "1":
+        init_scheduler(app)
 
     return app
 

--- a/docs/superpowers/plans/2026-07-17-practice-migration-create-all-recovery.md
+++ b/docs/superpowers/plans/2026-07-17-practice-migration-create-all-recovery.md
@@ -1,0 +1,1567 @@
+# Practice Migration `create_all` Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Alembic the sole schema authority, transactionally replace only the audited empty ORM-created summary-table orphan, and safely complete the interrupted practice-announcement deployment.
+
+**Architecture:** Application startup becomes schema-neutral, while the Render release command enters an explicit migration-only lifecycle before Python imports Slack. Migration `d8b2c6f4a901` locks and validates the exact orphan fingerprint before replacing it inside Alembic's PostgreSQL transaction; focused catalog tests and a real `scripts/release.sh` subprocess prove both success and rollback from the audited production starting state.
+
+**Tech Stack:** Python 3.11, Flask 3.1, Flask-Migrate/Alembic, Flask-SQLAlchemy/SQLAlchemy 2, PostgreSQL, Bash, pytest, Slack Bolt, Render, Git/GitHub CLI.
+
+## Global Constraints
+
+- Alembic is the only application schema authority. Remove runtime `db.create_all()` rather than hiding it behind an environment flag.
+- Only literal `TCSC_MIGRATION_ONLY=1` suppresses background startup; normal Render web workers retain their existing scheduler and Slack behavior.
+- `scripts/release.sh` must blank `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_SIGNING_SECRET` before Python imports `app.slack.bolt_app`.
+- Recover only a permanent, row-security-disabled, exact seven-column ORM-shaped `practice_summary_posts` table with its expected serial sequence, constraints, indexes, no timestamp defaults, and zero rows.
+- Acquire `ACCESS EXCLUSIVE` before fingerprint and emptiness validation and hold it through orphan replacement.
+- Any populated, canonical-looking, or structurally different pre-existing relation fails before `DROP TABLE`; errors identify invariants but never include Slack timestamps or practice data.
+- The `c4f1a8e2d9b7` changes, orphan replacement, legacy conflict checks, backfill, and revision update remain in one PostgreSQL transaction. A failure from the audited starting shape must restore the orphan, roll back all four `c4` columns, and leave revision `e36bbec59bde`.
+- Never stamp a revision, manually mutate production DDL, or retry an unchanged failed commit.
+- Keep the local Slack companion stopped and never post to `#announcements-practices`; Preview remains user-invoked only in `C07G9RTMRT3`.
+- Keep the practice-writer quiet window active until the deployed Preview succeeds.
+- Run PostgreSQL tests serially against the suite-pinned local database, with all Slack credentials explicitly blank.
+- Preserve the untracked `env` symlink and unrelated user changes.
+
+---
+
+## File Map
+
+- Modify `app/__init__.py`: remove runtime schema creation and skip the scheduler only during migration-only startup.
+- Modify `scripts/release.sh`: establish the migration-only process boundary and blank Slack credentials for `flask db upgrade`.
+- Create `tests/test_app_startup.py`: verify normal and migration-only app-factory behavior.
+- Create `tests/scripts/test_release.py`: verify the shell environment boundary and isolated import-time consumer state.
+- Modify `migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py`: lock, fingerprint, and replace only the exact empty orphan before the existing create/conflict/backfill flow.
+- Create `tests/practices/migration_test_support.py`: local-only catalog snapshot and exact-orphan helpers shared by migration tests.
+- Modify `tests/practices/test_practice_summary_post_migration.py`: cover normal creation, exact adoption, locking, and fail-closed variants without constructing the Flask app.
+- Create `tests/practices/test_practice_migration_release.py`: run the real release script from an isolated committed `e36` schema and prove success plus transactional rollback.
+- Create no production repair script; the repaired Alembic migration performs the one approved recovery.
+
+### Task 1: Make Startup Schema-Neutral and Release Migration-Only
+
+**Files:**
+
+- Modify: `app/__init__.py:74-82`
+- Modify: `scripts/release.sh:8-9`
+- Create: `tests/test_app_startup.py`
+- Create: `tests/scripts/test_release.py`
+
+**Interfaces:**
+
+- Consumes `TCSC_MIGRATION_ONLY` from the process environment.
+- Produces `create_app()` behavior that never calls `db.create_all()` and calls `init_scheduler(app)` unless the flag is exactly `"1"`.
+- Produces a release command that invokes exactly `flask db upgrade` with the migration flag set and all three Slack credentials present but empty.
+
+- [ ] **Step 1: Write the failing app-factory tests**
+
+Create `tests/test_app_startup.py`:
+
+```python
+from unittest.mock import Mock
+
+import app as app_module
+
+
+def _prepare_factory(monkeypatch):
+    monkeypatch.setattr(app_module, "load_stripe_config", lambda: None)
+    monkeypatch.setenv("FLASK_SECRET_KEY", "startup-test-secret")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql://tcsc:tcsc@localhost:5432/tcsc_trips",
+    )
+
+
+def test_create_app_never_calls_create_all(monkeypatch):
+    _prepare_factory(monkeypatch)
+    monkeypatch.delenv("TCSC_MIGRATION_ONLY", raising=False)
+    create_all = Mock(side_effect=AssertionError("schema mutation"))
+    scheduler = Mock(return_value=False)
+    monkeypatch.setattr(app_module.db, "create_all", create_all)
+    monkeypatch.setattr(app_module, "init_scheduler", scheduler)
+
+    application = app_module.create_app()
+
+    create_all.assert_not_called()
+    scheduler.assert_called_once_with(application)
+
+
+def test_create_app_skips_scheduler_in_migration_only_mode(monkeypatch):
+    _prepare_factory(monkeypatch)
+    monkeypatch.setenv("TCSC_MIGRATION_ONLY", "1")
+    create_all = Mock(side_effect=AssertionError("schema mutation"))
+    scheduler = Mock(return_value=False)
+    monkeypatch.setattr(app_module.db, "create_all", create_all)
+    monkeypatch.setattr(app_module, "init_scheduler", scheduler)
+
+    application = app_module.create_app()
+
+    assert "migrate" in application.extensions
+    create_all.assert_not_called()
+    scheduler.assert_not_called()
+```
+
+- [ ] **Step 2: Run the app-factory tests and verify RED**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest tests/test_app_startup.py -q
+```
+
+Expected: the first test fails because current `create_app()` calls
+`db.create_all()`; the second also cannot satisfy the migration-only contract.
+
+- [ ] **Step 3: Write the failing release-boundary tests**
+
+Create `tests/scripts/test_release.py`:
+
+```python
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE = ROOT / "scripts" / "release.sh"
+
+
+def test_release_runs_upgrade_with_migration_only_and_blank_slack_environment(
+    tmp_path,
+):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_flask = fake_bin / "flask"
+    fake_flask.write_text(
+        """#!/bin/sh
+{
+  printf 'argv=%s\\n' "$*"
+  printf 'migration_only=%s\\n' "${TCSC_MIGRATION_ONLY-unset}"
+  printf 'bot=%s\\n' "${SLACK_BOT_TOKEN-unset}"
+  printf 'app=%s\\n' "${SLACK_APP_TOKEN-unset}"
+  printf 'signing=%s\\n' "${SLACK_SIGNING_SECRET-unset}"
+} >> "$TCSC_RELEASE_CAPTURE"
+""",
+        encoding="utf-8",
+    )
+    fake_flask.chmod(0o755)
+    capture = tmp_path / "release-environment.txt"
+    environment = os.environ.copy()
+    environment.update({
+        "PATH": f"{fake_bin}{os.pathsep}{environment['PATH']}",
+        "TCSC_RELEASE_CAPTURE": str(capture),
+        "TCSC_MIGRATION_ONLY": "0",
+        "SLACK_BOT_TOKEN": "must-be-cleared",
+        "SLACK_APP_TOKEN": "must-be-cleared",
+        "SLACK_SIGNING_SECRET": "must-be-cleared",
+    })
+
+    result = subprocess.run(
+        ["bash", str(RELEASE)],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert capture.read_text(encoding="utf-8").splitlines() == [
+        "argv=db upgrade",
+        "migration_only=1",
+        "bot=",
+        "app=",
+        "signing=",
+    ]
+
+
+def test_migration_only_process_starts_no_background_consumers():
+    probe = r"""
+import json
+from unittest.mock import Mock
+
+import app as app_module
+import app.scheduler as scheduler_module
+import app.slack.bolt_app as bolt_module
+
+app_module.load_stripe_config = lambda: None
+create_all = Mock(side_effect=AssertionError("schema mutation"))
+init_scheduler = Mock(side_effect=AssertionError("background startup"))
+app_module.db.create_all = create_all
+app_module.init_scheduler = init_scheduler
+application = app_module.create_app()
+print(json.dumps({
+    "create_all_calls": create_all.call_count,
+    "scheduler_calls": init_scheduler.call_count,
+    "migrate_registered": "migrate" in application.extensions,
+    "bolt_enabled": bolt_module.is_bolt_enabled(),
+    "socket_available": bolt_module.is_socket_mode_available(),
+    "socket_running": bolt_module.is_socket_mode_running(),
+    "scheduler_running": scheduler_module.scheduler.running,
+}))
+"""
+    environment = os.environ.copy()
+    environment.update({
+        "DATABASE_URL": (
+            "postgresql://tcsc:tcsc@localhost:5432/tcsc_trips"
+        ),
+        "FLASK_SECRET_KEY": "release-process-test-secret",
+        "TCSC_MIGRATION_ONLY": "1",
+        "SLACK_BOT_TOKEN": "",
+        "SLACK_APP_TOKEN": "",
+        "SLACK_SIGNING_SECRET": "",
+    })
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    state = json.loads(result.stdout.strip().splitlines()[-1])
+    assert state == {
+        "create_all_calls": 0,
+        "scheduler_calls": 0,
+        "migrate_registered": True,
+        "bolt_enabled": False,
+        "socket_available": False,
+        "socket_running": False,
+        "scheduler_running": False,
+    }
+```
+
+- [ ] **Step 4: Run the release-boundary tests and verify RED**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest tests/scripts/test_release.py -q
+```
+
+Expected: the fake command sees the sentinel values and no migration flag;
+the isolated process fails on the current runtime `create_all()` call.
+
+- [ ] **Step 5: Remove runtime schema creation and gate only background startup**
+
+In `app/__init__.py`, replace the existing `create_all()` and scheduler block
+with:
+
+```python
+    # Schema changes belong exclusively to Alembic. Migration commands still
+    # need the Flask-Migrate extension, but must not start background workers.
+    if os.getenv("TCSC_MIGRATION_ONLY") != "1":
+        init_scheduler(app)
+
+    return app
+```
+
+Keep `Migrate(app, db)` registered earlier in the factory. Do not retain any
+`db.create_all()` call or add an alternate schema-initialization path.
+
+- [ ] **Step 6: Establish the release process boundary before Python import**
+
+Replace the migration command in `scripts/release.sh` with:
+
+```bash
+env \
+  TCSC_MIGRATION_ONLY=1 \
+  SLACK_BOT_TOKEN= \
+  SLACK_APP_TOKEN= \
+  SLACK_SIGNING_SECRET= \
+  flask db upgrade
+```
+
+Do not move credential blanking into Python: `bolt_app` snapshots those values
+at import time.
+
+- [ ] **Step 7: Run the startup/release tests and verify GREEN**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest tests/test_app_startup.py tests/scripts/test_release.py -q
+```
+
+Expected: four tests pass; no PostgreSQL schema or Slack state is mutated.
+
+- [ ] **Step 8: Commit the startup boundary**
+
+```bash
+git add app/__init__.py scripts/release.sh \
+  tests/test_app_startup.py tests/scripts/test_release.py
+git commit -m "fix(deploy): isolate migration startup"
+```
+
+### Task 2: Adopt Only the Exact Empty ORM Orphan
+
+**Files:**
+
+- Modify: `migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py`
+- Create: `tests/practices/migration_test_support.py`
+- Modify: `tests/practices/test_practice_summary_post_migration.py`
+
+**Interfaces:**
+
+- Produces `_visible_summary_table_oid(bind) -> int | None`.
+- Produces `_lock_existing_summary_table(bind, relation_oid: int) -> int`, which holds `AccessExclusiveLock` until the surrounding transaction ends.
+- Produces `_summary_table_fingerprint(bind, relation_oid: int) -> dict` and `_assert_exact_empty_create_all_orphan(bind, relation_oid: int) -> None`.
+- Produces `_drop_exact_empty_create_all_orphan_if_present(bind) -> bool`; `upgrade()` calls it immediately before the existing canonical create/conflict/backfill flow.
+- Test support produces `create_exact_summary_orphan(connection)` and `summary_catalog_snapshot(connection)` without calling `create_app()` or `db.create_all()`.
+
+- [ ] **Step 1: Add independent exact-orphan and catalog-snapshot test helpers**
+
+Create `tests/practices/migration_test_support.py`:
+
+```python
+from sqlalchemy import text
+
+from app.practices.models import PracticeSummaryPost
+
+
+def create_exact_summary_orphan(connection):
+    """Create only the ORM table in the active test schema."""
+    PracticeSummaryPost.__table__.create(connection)
+
+
+def summary_catalog_snapshot(connection):
+    relation = connection.execute(text("""
+        SELECT c.oid, c.relkind, c.relpersistence,
+               c.relrowsecurity, c.relforcerowsecurity
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relname = 'practice_summary_posts'
+    """)).mappings().one_or_none()
+    if relation is None:
+        return None
+    oid = relation["oid"]
+    columns = connection.execute(text("""
+        SELECT a.attnum, a.attname,
+               format_type(a.atttypid, a.atttypmod) AS sql_type,
+               a.attnotnull, a.attidentity, a.attgenerated,
+               pg_get_expr(d.adbin, d.adrelid) AS default_expr
+        FROM pg_attribute AS a
+        LEFT JOIN pg_attrdef AS d
+          ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+        WHERE a.attrelid = :oid
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY a.attnum
+    """), {"oid": oid}).all()
+    constraints = connection.execute(text("""
+        SELECT con.conname, con.contype,
+               coalesce(
+                 array_agg(a.attname ORDER BY key.ord)
+                   FILTER (WHERE a.attname IS NOT NULL),
+                 ARRAY[]::name[]
+               ) AS columns,
+               pg_get_constraintdef(con.oid, true) AS definition
+        FROM pg_constraint AS con
+        LEFT JOIN LATERAL
+          unnest(con.conkey) WITH ORDINALITY AS key(attnum, ord) ON true
+        LEFT JOIN pg_attribute AS a
+          ON a.attrelid = con.conrelid AND a.attnum = key.attnum
+        WHERE con.conrelid = :oid
+          AND con.contype IN ('c', 'p', 'u', 'f', 'x')
+        GROUP BY con.oid, con.conname, con.contype
+        ORDER BY con.conname
+    """), {"oid": oid}).all()
+    indexes = connection.execute(text("""
+        SELECT idx.relname, ind.indisprimary, ind.indisunique,
+               ind.indisvalid, ind.indisready,
+               am.amname, ind.indnkeyatts, ind.indnatts,
+               array_agg(a.attname ORDER BY key.ord) AS columns,
+               pg_get_expr(ind.indpred, ind.indrelid) AS predicate,
+               pg_get_expr(ind.indexprs, ind.indrelid) AS expressions
+        FROM pg_index AS ind
+        JOIN pg_class AS idx ON idx.oid = ind.indexrelid
+        JOIN pg_am AS am ON am.oid = idx.relam
+        JOIN LATERAL
+          unnest(ind.indkey::smallint[]) WITH ORDINALITY
+          AS key(attnum, ord) ON true
+        LEFT JOIN pg_attribute AS a
+          ON a.attrelid = ind.indrelid AND a.attnum = key.attnum
+        WHERE ind.indrelid = :oid
+        GROUP BY idx.relname, ind.indisprimary, ind.indisunique,
+                 ind.indisvalid, ind.indisready,
+                 am.amname, ind.indnkeyatts, ind.indnatts,
+                 ind.indpred, ind.indexprs, ind.indrelid
+        ORDER BY idx.relname
+    """), {"oid": oid}).all()
+    sequence = connection.execute(text("""
+        SELECT seq_ns.nspname, seq.relname,
+               ownership.deptype, default_dep.deptype
+        FROM pg_class AS table_rel
+        JOIN pg_attribute AS id_column
+          ON id_column.attrelid = table_rel.oid
+         AND id_column.attname = 'id'
+        JOIN pg_attrdef AS id_default
+          ON id_default.adrelid = table_rel.oid
+         AND id_default.adnum = id_column.attnum
+        JOIN pg_depend AS ownership
+          ON ownership.refobjid = table_rel.oid
+         AND ownership.refobjsubid = id_column.attnum
+         AND ownership.deptype = 'a'
+        JOIN pg_class AS seq
+          ON seq.oid = ownership.objid AND seq.relkind = 'S'
+        JOIN pg_namespace AS seq_ns ON seq_ns.oid = seq.relnamespace
+        JOIN pg_depend AS default_dep
+          ON default_dep.classid = 'pg_attrdef'::regclass
+         AND default_dep.objid = id_default.oid
+         AND default_dep.refobjid = seq.oid
+        WHERE table_rel.oid = :oid
+        ORDER BY seq_ns.nspname, seq.relname
+    """), {"oid": oid}).all()
+    row_count = connection.exec_driver_sql(
+        "SELECT count(*) FROM practice_summary_posts"
+    ).scalar_one()
+    return {
+        "relation": tuple(relation[key] for key in (
+            "relkind", "relpersistence", "relrowsecurity",
+            "relforcerowsecurity",
+        )),
+        "columns": [tuple(row) for row in columns],
+        "constraints": [
+            (row[0], row[1], tuple(row[2]), " ".join(row[3].split()))
+            for row in constraints
+        ],
+        "indexes": [
+            (*tuple(row[:8]), tuple(row[8]), row[9], row[10])
+            for row in indexes
+        ],
+        "sequence": [tuple(row) for row in sequence],
+        "row_count": row_count,
+    }
+```
+
+This helper is test-only and intentionally uses catalog queries independent of
+the migration helper implementation.
+
+- [ ] **Step 2: Refactor the migration test harness away from Flask startup**
+
+Replace the `create_app()`/`db` fixtures in
+`tests/practices/test_practice_summary_post_migration.py` with:
+
+```python
+from contextlib import contextmanager
+from datetime import date
+import os
+from uuid import uuid4
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.exc import DBAPIError
+
+from migrations.versions import (
+    d8b2c6f4a901_add_practice_summary_posts as revision,
+)
+from tests._db_guard import is_local_db
+from tests.practices.migration_test_support import (
+    create_exact_summary_orphan,
+    summary_catalog_snapshot,
+)
+
+
+@pytest.fixture(scope="module")
+def engine():
+    database_url = os.environ["DATABASE_URL"]
+    assert is_local_db(database_url), "migration tests require local PostgreSQL"
+    local_engine = create_engine(database_url)
+    yield local_engine
+    local_engine.dispose()
+
+
+@contextmanager
+def migration_schema(engine, prefix="practice_summary"):
+    schema = f"{prefix}_{uuid4().hex}"
+    connection = engine.connect()
+    transaction = connection.begin()
+    try:
+        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+        connection.exec_driver_sql(f'SET LOCAL search_path TO "{schema}"')
+        yield connection, schema
+    finally:
+        transaction.rollback()
+        connection.close()
+
+
+def configure_revision(connection, monkeypatch):
+    context = MigrationContext.configure(connection)
+    monkeypatch.setattr(revision, "op", Operations(context))
+
+
+def create_legacy_practices_table(connection):
+    connection.exec_driver_sql("""
+        CREATE TABLE practices (
+            id INTEGER PRIMARY KEY,
+            date TIMESTAMP NOT NULL,
+            slack_coach_summary_ts VARCHAR(50),
+            slack_weekly_summary_ts VARCHAR(50)
+        )
+    """)
+```
+
+Update the three existing tests to consume `engine` and
+`migration_schema(...)`, call `configure_revision(...)`, and retain their
+existing rows and assertions. Do not initialize the Flask application.
+
+- [ ] **Step 3: Write the failing normal, lock, and exact-adoption tests**
+
+Add these tests to the same file:
+
+```python
+def test_upgrade_without_existing_summary_table_uses_normal_path(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_normal") as (connection, schema):
+        create_legacy_practices_table(connection)
+        configure_revision(connection, monkeypatch)
+
+        revision.upgrade()
+
+        assert inspect(connection).has_table(
+            "practice_summary_posts", schema=schema
+        )
+        defaults = {
+            row[0]: row[1]
+            for row in connection.execute(text("""
+                SELECT column_name, column_default
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'practice_summary_posts'
+                  AND column_name IN ('created_at', 'updated_at')
+            """))
+        }
+        assert defaults == {"created_at": "now()", "updated_at": "now()"}
+
+
+def test_existing_orphan_lock_is_access_exclusive(engine):
+    with migration_schema(engine, "summary_lock") as (connection, _schema):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        oid = revision._visible_summary_table_oid(connection)
+
+        locked_oid = revision._lock_existing_summary_table(connection, oid)
+
+        assert locked_oid == oid
+        locks = connection.execute(text("""
+            SELECT mode, granted
+            FROM pg_locks
+            WHERE pid = pg_backend_pid()
+              AND relation = :oid
+              AND mode = 'AccessExclusiveLock'
+        """), {"oid": oid}).all()
+        assert locks == [("AccessExclusiveLock", True)]
+
+
+def test_upgrade_adopts_exact_empty_orm_orphan_and_backfills(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_adopt") as (connection, _schema):
+        create_legacy_practices_table(connection)
+        connection.exec_driver_sql("""
+            INSERT INTO practices (
+                id, date, slack_coach_summary_ts, slack_weekly_summary_ts
+            ) VALUES
+                (1, '2026-07-13 18:00', 'coach-1', 'public-1'),
+                (2, '2026-07-15 18:00', 'coach-1', 'public-1')
+        """)
+        create_exact_summary_orphan(connection)
+        before = summary_catalog_snapshot(connection)
+        assert before["row_count"] == 0
+        assert dict(
+            (row[1], row[6]) for row in before["columns"]
+        )["created_at"] is None
+        configure_revision(connection, monkeypatch)
+
+        revision.upgrade()
+
+        after = summary_catalog_snapshot(connection)
+        defaults = {row[1]: row[6] for row in after["columns"]}
+        assert defaults["created_at"] == "now()"
+        assert defaults["updated_at"] == "now()"
+        rows = connection.exec_driver_sql("""
+            SELECT week_start, surface, channel_id, message_ts
+            FROM practice_summary_posts
+            ORDER BY surface
+        """).all()
+        assert rows == [
+            (date(2026, 7, 13), "coach_summary", None, "coach-1"),
+            (date(2026, 7, 13), "weekly_summary", None, "public-1"),
+        ]
+```
+
+- [ ] **Step 4: Write the failing fail-closed fingerprint tests**
+
+Add:
+
+```python
+def _assert_upgrade_refused_without_mutation(connection, monkeypatch):
+    before = summary_catalog_snapshot(connection)
+    configure_revision(connection, monkeypatch)
+
+    savepoint = connection.begin_nested()
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="practice_summary_posts orphan recovery refused",
+        ):
+            revision.upgrade()
+    finally:
+        savepoint.rollback()
+
+    assert summary_catalog_snapshot(connection) == before
+
+
+def test_upgrade_refuses_nonempty_orm_orphan_without_mutation(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_nonempty") as (connection, _schema):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            INSERT INTO practice_summary_posts (
+                id, week_start, surface, message_ts, created_at, updated_at
+            ) VALUES (
+                1, '2026-07-13', 'weekly_summary', 'existing', now(), now()
+            )
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+@pytest.mark.parametrize(
+    "malformation",
+    [
+        pytest.param(
+            "ALTER TABLE practice_summary_posts DROP CONSTRAINT "
+            "ck_practice_summary_post_surface",
+            id="missing-check",
+        ),
+        pytest.param(
+            "CREATE INDEX unexpected_summary_message_index "
+            "ON practice_summary_posts (message_ts)",
+            id="unexpected-index",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts SET UNLOGGED",
+            id="non-permanent-relation",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts ENABLE ROW LEVEL SECURITY",
+            id="row-security",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts "
+            "ALTER COLUMN channel_id TYPE VARCHAR(51)",
+            id="column-shape",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts ALTER COLUMN id DROP DEFAULT",
+            id="serial-default",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts DROP CONSTRAINT "
+            "practice_summary_posts_pkey",
+            id="missing-primary-key",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts DROP CONSTRAINT "
+            "uq_practice_summary_post_week_surface",
+            id="missing-unique",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts ADD CONSTRAINT "
+            "unexpected_summary_fk FOREIGN KEY (id) "
+            "REFERENCES practice_summary_posts(id)",
+            id="unexpected-foreign-key",
+        ),
+        pytest.param(
+            "ALTER SEQUENCE practice_summary_posts_id_seq "
+            "RENAME TO unexpected_summary_id_seq",
+            id="sequence-identity",
+        ),
+    ],
+)
+def test_upgrade_refuses_malformed_orm_orphan_without_mutation(
+    engine, monkeypatch, malformation,
+):
+    with migration_schema(engine, "summary_malformed") as (
+        connection, _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql(malformation)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+def test_upgrade_refuses_non_table_relation_without_mutation(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_view") as (connection, _schema):
+        create_legacy_practices_table(connection)
+        connection.exec_driver_sql("""
+            CREATE VIEW practice_summary_posts AS
+            SELECT
+                1::integer AS id,
+                DATE '2026-07-13' AS week_start,
+                'coach_summary'::varchar(32) AS surface,
+                NULL::varchar(50) AS channel_id,
+                'view-message'::varchar(50) AS message_ts,
+                now()::timestamp AS created_at,
+                now()::timestamp AS updated_at
+            WHERE FALSE
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+def test_upgrade_refuses_canonical_preexisting_table_without_mutation(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_canonical") as (
+        connection, _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            ALTER TABLE practice_summary_posts
+              ALTER COLUMN created_at SET DEFAULT now(),
+              ALTER COLUMN updated_at SET DEFAULT now()
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+```
+
+- [ ] **Step 5: Run all migration tests and verify RED**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest tests/practices/test_practice_summary_post_migration.py -q
+```
+
+Expected: the new tests fail because the lock/fingerprint helpers do not exist
+and current `upgrade()` collides with any pre-existing table. The three
+existing normal/conflict tests continue to establish their prior behavior.
+
+- [ ] **Step 6: Add exact fingerprint constants and catalog helpers to `d8`**
+
+Add these constants and helpers above `upgrade()` in
+`migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py`:
+
+```python
+SUMMARY_TABLE = "practice_summary_posts"
+
+_EXPECTED_COLUMN_SHAPE = (
+    (1, "id", "integer", True, "", ""),
+    (2, "week_start", "date", True, "", ""),
+    (3, "surface", "character varying(32)", True, "", ""),
+    (4, "channel_id", "character varying(50)", False, "", ""),
+    (5, "message_ts", "character varying(50)", True, "", ""),
+    (6, "created_at", "timestamp without time zone", True, "", ""),
+    (7, "updated_at", "timestamp without time zone", True, "", ""),
+)
+
+_EXPECTED_CONSTRAINTS = (
+    (
+        "ck_practice_summary_post_surface",
+        "c",
+        ("surface",),
+        "CHECK (surface::text = ANY (ARRAY['coach_summary'::character "
+        "varying, 'weekly_summary'::character varying]::text[]))",
+    ),
+    (
+        "practice_summary_posts_pkey",
+        "p",
+        ("id",),
+        "PRIMARY KEY (id)",
+    ),
+    (
+        "uq_practice_summary_post_week_surface",
+        "u",
+        ("week_start", "surface"),
+        "UNIQUE (week_start, surface)",
+    ),
+)
+
+_EXPECTED_INDEXES = (
+    (
+        "practice_summary_posts_pkey", True, True, True, True,
+        "btree", 1, 1,
+        ("id",), None, None,
+    ),
+    (
+        "uq_practice_summary_post_week_surface", False, True, True, True,
+        "btree", 2, 2,
+        ("week_start", "surface"), None, None,
+    ),
+)
+
+
+def _refuse_orphan_recovery(invariant):
+    raise RuntimeError(
+        "practice_summary_posts orphan recovery refused: " + invariant
+    )
+
+
+def _visible_summary_relation(bind):
+    row = bind.execute(sa.text("""
+        SELECT c.oid, n.nspname AS schema_name, c.relkind,
+               c.relpersistence, c.relrowsecurity, c.relforcerowsecurity
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relname = :table_name
+    """), {"table_name": SUMMARY_TABLE}).mappings().one_or_none()
+    return dict(row) if row is not None else None
+
+
+def _visible_summary_table_oid(bind):
+    relation = _visible_summary_relation(bind)
+    return None if relation is None else relation["oid"]
+
+
+def _lock_existing_summary_table(bind, relation_oid):
+    relation = _visible_summary_relation(bind)
+    if relation is None or relation["oid"] != relation_oid:
+        _refuse_orphan_recovery("relation changed before lock")
+    quote = bind.dialect.identifier_preparer.quote
+    qualified = (
+        f"{quote(relation['schema_name'])}.{quote(SUMMARY_TABLE)}"
+    )
+    try:
+        bind.exec_driver_sql(
+            f"LOCK TABLE {qualified} IN ACCESS EXCLUSIVE MODE"
+        )
+    except sa.exc.DBAPIError as error:
+        raise RuntimeError(
+            "practice_summary_posts orphan recovery refused: "
+            "relation could not be locked"
+        ) from error
+    locked = _visible_summary_relation(bind)
+    if locked is None or locked["oid"] != relation_oid:
+        _refuse_orphan_recovery("relation changed while acquiring lock")
+    return relation_oid
+```
+
+These exact constants, including `indisvalid` and `indisready`, were compared
+read-only with the production orphan on 2026-07-17. Do not broaden them to
+accept alternate table shapes.
+
+- [ ] **Step 7: Add the complete locked fingerprint reader**
+
+Continue in the migration file:
+
+```python
+def _summary_table_fingerprint(bind, relation_oid):
+    relation = _visible_summary_relation(bind)
+    if relation is None or relation["oid"] != relation_oid:
+        _refuse_orphan_recovery("locked relation is no longer visible")
+    columns = bind.execute(sa.text("""
+        SELECT a.attnum, a.attname,
+               format_type(a.atttypid, a.atttypmod) AS sql_type,
+               a.attnotnull, a.attidentity, a.attgenerated,
+               pg_get_expr(d.adbin, d.adrelid) AS default_expr
+        FROM pg_attribute AS a
+        LEFT JOIN pg_attrdef AS d
+          ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+        WHERE a.attrelid = :oid
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY a.attnum
+    """), {"oid": relation_oid}).all()
+    constraints = bind.execute(sa.text("""
+        SELECT con.conname, con.contype,
+               coalesce(
+                 array_agg(a.attname ORDER BY key.ord)
+                   FILTER (WHERE a.attname IS NOT NULL),
+                 ARRAY[]::name[]
+               ) AS columns,
+               pg_get_constraintdef(con.oid, true) AS definition
+        FROM pg_constraint AS con
+        LEFT JOIN LATERAL
+          unnest(con.conkey) WITH ORDINALITY AS key(attnum, ord) ON true
+        LEFT JOIN pg_attribute AS a
+          ON a.attrelid = con.conrelid AND a.attnum = key.attnum
+        WHERE con.conrelid = :oid
+          AND con.contype IN ('c', 'p', 'u', 'f', 'x')
+        GROUP BY con.oid, con.conname, con.contype
+        ORDER BY con.conname
+    """), {"oid": relation_oid}).all()
+    indexes = bind.execute(sa.text("""
+        SELECT idx.relname, ind.indisprimary, ind.indisunique,
+               ind.indisvalid, ind.indisready,
+               am.amname, ind.indnkeyatts, ind.indnatts,
+               array_agg(a.attname ORDER BY key.ord) AS columns,
+               pg_get_expr(ind.indpred, ind.indrelid) AS predicate,
+               pg_get_expr(ind.indexprs, ind.indrelid) AS expressions
+        FROM pg_index AS ind
+        JOIN pg_class AS idx ON idx.oid = ind.indexrelid
+        JOIN pg_am AS am ON am.oid = idx.relam
+        JOIN LATERAL
+          unnest(ind.indkey::smallint[]) WITH ORDINALITY
+          AS key(attnum, ord) ON true
+        LEFT JOIN pg_attribute AS a
+          ON a.attrelid = ind.indrelid AND a.attnum = key.attnum
+        WHERE ind.indrelid = :oid
+        GROUP BY idx.relname, ind.indisprimary, ind.indisunique,
+                 ind.indisvalid, ind.indisready,
+                 am.amname, ind.indnkeyatts, ind.indnatts,
+                 ind.indpred, ind.indexprs, ind.indrelid
+        ORDER BY idx.relname
+    """), {"oid": relation_oid}).all()
+    sequence = bind.execute(sa.text("""
+        SELECT seq_ns.nspname, seq.relname,
+               ownership.deptype, default_dep.deptype
+        FROM pg_class AS table_rel
+        JOIN pg_attribute AS id_column
+          ON id_column.attrelid = table_rel.oid
+         AND id_column.attname = 'id'
+        JOIN pg_attrdef AS id_default
+          ON id_default.adrelid = table_rel.oid
+         AND id_default.adnum = id_column.attnum
+        JOIN pg_depend AS ownership
+          ON ownership.refobjid = table_rel.oid
+         AND ownership.refobjsubid = id_column.attnum
+         AND ownership.deptype = 'a'
+        JOIN pg_class AS seq
+          ON seq.oid = ownership.objid AND seq.relkind = 'S'
+        JOIN pg_namespace AS seq_ns ON seq_ns.oid = seq.relnamespace
+        JOIN pg_depend AS default_dep
+          ON default_dep.classid = 'pg_attrdef'::regclass
+         AND default_dep.objid = id_default.oid
+         AND default_dep.refobjid = seq.oid
+        WHERE table_rel.oid = :oid
+        ORDER BY seq_ns.nspname, seq.relname
+    """), {"oid": relation_oid}).all()
+    has_rows = bind.exec_driver_sql(
+        "SELECT EXISTS (SELECT 1 FROM practice_summary_posts LIMIT 1)"
+    ).scalar_one()
+    return {
+        "relation": (
+            relation["relkind"], relation["relpersistence"],
+            relation["relrowsecurity"], relation["relforcerowsecurity"],
+        ),
+        "schema": relation["schema_name"],
+        "columns": [tuple(row) for row in columns],
+        "constraints": tuple(
+            (row[0], row[1], tuple(row[2]), " ".join(row[3].split()))
+            for row in constraints
+        ),
+        "indexes": tuple(
+            (*tuple(row[:8]), tuple(row[8]), row[9], row[10])
+            for row in indexes
+        ),
+        "sequence": [tuple(row) for row in sequence],
+        "has_rows": has_rows,
+    }
+```
+
+- [ ] **Step 8: Validate every invariant and drop only after all pass**
+
+Add:
+
+```python
+def _assert_exact_empty_create_all_orphan(bind, relation_oid):
+    fingerprint = _summary_table_fingerprint(bind, relation_oid)
+    if fingerprint["relation"] != ("r", "p", False, False):
+        _refuse_orphan_recovery("relation metadata mismatch")
+    columns = fingerprint["columns"]
+    shape = tuple(row[:6] for row in columns)
+    if shape != _EXPECTED_COLUMN_SHAPE:
+        _refuse_orphan_recovery("column shape mismatch")
+    id_default = columns[0][6]
+    if not id_default or not id_default.startswith("nextval("):
+        _refuse_orphan_recovery("id serial default mismatch")
+    if any(row[6] is not None for row in columns[1:]):
+        _refuse_orphan_recovery("non-id column default mismatch")
+    expected_sequence = [(
+        fingerprint["schema"],
+        "practice_summary_posts_id_seq",
+        "a",
+        "n",
+    )]
+    if fingerprint["sequence"] != expected_sequence:
+        _refuse_orphan_recovery("owned serial sequence mismatch")
+    if fingerprint["constraints"] != _EXPECTED_CONSTRAINTS:
+        _refuse_orphan_recovery("constraint mismatch")
+    if fingerprint["indexes"] != _EXPECTED_INDEXES:
+        _refuse_orphan_recovery("index mismatch")
+    if fingerprint["has_rows"]:
+        _refuse_orphan_recovery("table contains rows")
+
+
+def _drop_exact_empty_create_all_orphan_if_present(bind):
+    relation_oid = _visible_summary_table_oid(bind)
+    if relation_oid is None:
+        return False
+    _lock_existing_summary_table(bind, relation_oid)
+    _assert_exact_empty_create_all_orphan(bind, relation_oid)
+    op.drop_table(SUMMARY_TABLE)
+    return True
+```
+
+At the first line of `upgrade()`, before the existing canonical
+`op.create_table(...)`, add:
+
+```python
+    _drop_exact_empty_create_all_orphan_if_present(op.get_bind())
+```
+
+Leave the canonical table definition, same-week/cross-week conflict block,
+backfill SQL, and downgrade behavior unchanged.
+
+- [ ] **Step 9: Run migration tests and verify GREEN**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest tests/practices/test_practice_summary_post_migration.py -q
+```
+
+Expected: normal create/downgrade, lock, exact adoption, nonempty refusal,
+malformed refusal, canonical refusal, and both legacy conflict cases pass.
+
+- [ ] **Step 10: Commit the locked orphan recovery**
+
+```bash
+git add migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py \
+  tests/practices/migration_test_support.py \
+  tests/practices/test_practice_summary_post_migration.py
+git commit -m "fix(practices): recover empty summary orphan"
+```
+
+### Task 3: Prove the Real Release Lifecycle and Transaction Rollback
+
+**Files:**
+
+- Create: `tests/practices/test_practice_migration_release.py`
+- Reuse: `tests/practices/migration_test_support.py`
+
+**Interfaces:**
+
+- Consumes the migration-only `scripts/release.sh` contract from Task 1 and the locked orphan recovery from Task 2.
+- Produces `_create_e36_baseline(connection, *, conflicting: bool) -> None`, `_schema_database_url(schema: str) -> str`, and `_run_release(schema: str) -> subprocess.CompletedProcess[str]` inside the test module.
+- Proves the exact audited start state—revision `e36bbec59bde`, four absent `c4` columns, and an empty ORM orphan—reaches `d8b2c6f4a901` or rolls back completely after a post-replacement conflict.
+
+- [ ] **Step 1: Create a committed isolated-schema release harness**
+
+Create `tests/practices/test_practice_migration_release.py` with these imports,
+fixtures, and helpers:
+
+```python
+from datetime import date
+import os
+from pathlib import Path
+import subprocess
+import sys
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+
+from tests._db_guard import is_local_db
+from tests.practices.migration_test_support import (
+    create_exact_summary_orphan,
+    summary_catalog_snapshot,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE = ROOT / "scripts" / "release.sh"
+E36 = "e36bbec59bde"
+D8 = "d8b2c6f4a901"
+EXPECTED_C4_COLUMNS = {
+    ("practice_activities", "default_plan_reactions"),
+    ("practice_types", "default_plan_reactions"),
+    ("practices", "plan_reactions"),
+    ("practices", "slack_session_emoji"),
+}
+
+
+@pytest.fixture(scope="module")
+def engine():
+    database_url = os.environ["DATABASE_URL"]
+    assert is_local_db(database_url), "release tests require local PostgreSQL"
+    local_engine = create_engine(database_url)
+    yield local_engine
+    local_engine.dispose()
+
+
+@pytest.fixture
+def release_schema(engine):
+    schema = f"practice_release_{uuid4().hex}"
+    with engine.begin() as connection:
+        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+    try:
+        yield schema
+    finally:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(f'DROP SCHEMA "{schema}" CASCADE')
+
+
+def _use_schema(connection, schema):
+    connection.exec_driver_sql(f'SET search_path TO "{schema}"')
+
+
+def _create_e36_baseline(connection, *, conflicting):
+    connection.exec_driver_sql("""
+        CREATE TABLE alembic_version (
+            version_num VARCHAR(32) NOT NULL,
+            CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+        )
+    """)
+    connection.exec_driver_sql(
+        "INSERT INTO alembic_version VALUES ('e36bbec59bde')"
+    )
+    connection.exec_driver_sql(
+        "CREATE TABLE practice_activities (id INTEGER PRIMARY KEY)"
+    )
+    connection.exec_driver_sql("""
+        CREATE TABLE practice_types (
+            id INTEGER PRIMARY KEY,
+            has_intervals BOOLEAN NOT NULL
+        )
+    """)
+    connection.exec_driver_sql("""
+        CREATE TABLE practices (
+            id INTEGER PRIMARY KEY,
+            date TIMESTAMP NOT NULL,
+            slack_coach_summary_ts VARCHAR(50),
+            slack_weekly_summary_ts VARCHAR(50)
+        )
+    """)
+    connection.exec_driver_sql("""
+        CREATE TABLE practice_types_junction (
+            practice_id INTEGER NOT NULL,
+            type_id INTEGER NOT NULL
+        )
+    """)
+    connection.exec_driver_sql(
+        "INSERT INTO practice_activities VALUES (1)"
+    )
+    connection.exec_driver_sql(
+        "INSERT INTO practice_types VALUES (10, TRUE), (20, FALSE)"
+    )
+    second_public = "public-2" if conflicting else "public-1"
+    connection.execute(text("""
+        INSERT INTO practices (
+            id, date, slack_coach_summary_ts, slack_weekly_summary_ts
+        ) VALUES
+            (1, '2026-07-13 18:00', 'coach-1', 'public-1'),
+            (2, '2026-07-15 18:00', 'coach-1', :second_public)
+    """), {"second_public": second_public})
+    connection.exec_driver_sql(
+        "INSERT INTO practice_types_junction VALUES (1, 10), (2, 20)"
+    )
+    create_exact_summary_orphan(connection)
+
+
+def _schema_database_url(schema):
+    url = make_url(os.environ["DATABASE_URL"])
+    scoped = url.update_query_dict({
+        "options": f"-csearch_path={schema}",
+    })
+    return scoped.render_as_string(hide_password=False)
+
+
+def _run_release(schema):
+    environment = os.environ.copy()
+    environment.update({
+        "PATH": (
+            f"{Path(sys.executable).parent}{os.pathsep}"
+            f"{environment['PATH']}"
+        ),
+        "DATABASE_URL": _schema_database_url(schema),
+        "FLASK_ENV": "testing",
+        "FLASK_SECRET_KEY": "release-lifecycle-secret",
+        "STRIPE_SECRET_KEY": "sk_test_release_lifecycle",
+        "TCSC_MIGRATION_ONLY": "0",
+        "SLACK_BOT_TOKEN": "must-be-cleared",
+        "SLACK_APP_TOKEN": "must-be-cleared",
+        "SLACK_SIGNING_SECRET": "must-be-cleared",
+        "RENDER": "",
+    })
+    return subprocess.run(
+        ["bash", str(RELEASE)],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _revision(connection):
+    return connection.exec_driver_sql(
+        "SELECT version_num FROM alembic_version"
+    ).scalar_one()
+
+
+def _c4_columns(connection):
+    rows = connection.execute(text("""
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND (table_name, column_name) IN (
+            ('practice_activities', 'default_plan_reactions'),
+            ('practice_types', 'default_plan_reactions'),
+            ('practices', 'plan_reactions'),
+            ('practices', 'slack_session_emoji')
+          )
+    """)).all()
+    return {tuple(row) for row in rows}
+```
+
+The schema setup must commit before `_run_release()` because the subprocess
+uses a separate PostgreSQL connection. The fixture drops only its UUID-owned
+schema.
+
+- [ ] **Step 2: Add the successful real-release regression**
+
+```python
+def test_release_lifecycle_upgrades_e36_orphan_to_d8_without_consumers(
+    engine, release_schema,
+):
+    with engine.begin() as connection:
+        _use_schema(connection, release_schema)
+        _create_e36_baseline(connection, conflicting=False)
+        baseline = summary_catalog_snapshot(connection)
+        assert _revision(connection) == E36
+        assert _c4_columns(connection) == set()
+        assert baseline["row_count"] == 0
+        baseline_defaults = {row[1]: row[6] for row in baseline["columns"]}
+        assert baseline_defaults["created_at"] is None
+        assert baseline_defaults["updated_at"] is None
+
+    result = _run_release(release_schema)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    output = result.stdout + result.stderr
+    assert "APScheduler started successfully" not in output
+    assert "Slack Bolt enabled" not in output
+    assert "Socket Mode" not in output
+    with engine.connect() as connection:
+        _use_schema(connection, release_schema)
+        assert _revision(connection) == D8
+        assert _c4_columns(connection) == EXPECTED_C4_COLUMNS
+        after = summary_catalog_snapshot(connection)
+        defaults = {row[1]: row[6] for row in after["columns"]}
+        assert defaults["created_at"] == "now()"
+        assert defaults["updated_at"] == "now()"
+        assert connection.exec_driver_sql("""
+            SELECT week_start, surface, channel_id, message_ts
+            FROM practice_summary_posts
+            ORDER BY surface
+        """).all() == [
+            (date(2026, 7, 13), "coach_summary", None, "coach-1"),
+            (date(2026, 7, 13), "weekly_summary", None, "public-1"),
+        ]
+```
+
+- [ ] **Step 3: Add the forced post-replacement rollback regression**
+
+```python
+def test_release_lifecycle_conflict_rolls_back_c4_and_restores_orphan(
+    engine, release_schema,
+):
+    with engine.begin() as connection:
+        _use_schema(connection, release_schema)
+        _create_e36_baseline(connection, conflicting=True)
+        baseline = summary_catalog_snapshot(connection)
+        assert _revision(connection) == E36
+        assert _c4_columns(connection) == set()
+
+    result = _run_release(release_schema)
+
+    assert result.returncode != 0
+    assert "conflicting legacy practice summary timestamps" in (
+        result.stdout + result.stderr
+    )
+    with engine.connect() as connection:
+        _use_schema(connection, release_schema)
+        assert _revision(connection) == E36
+        assert _c4_columns(connection) == set()
+        assert summary_catalog_snapshot(connection) == baseline
+        defaults = {
+            row[1]: row[6]
+            for row in summary_catalog_snapshot(connection)["columns"]
+        }
+        assert defaults["created_at"] is None
+        assert defaults["updated_at"] is None
+```
+
+- [ ] **Step 4: Run the lifecycle file in isolation**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest tests/practices/test_practice_migration_release.py -q
+```
+
+Expected: both subprocess tests pass. The success path reaches `d8`; the
+forced conflict fails inside `d8` but restores the exact baseline catalog,
+four absent `c4` columns, and revision `e36`.
+
+- [ ] **Step 5: Run the complete hotfix regression set**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest \
+    tests/test_app_startup.py \
+    tests/scripts/test_release.py \
+    tests/practices/test_plan_reaction_migration.py \
+    tests/practices/test_practice_summary_post_migration.py \
+    tests/practices/test_practice_migration_release.py -q
+```
+
+Expected: startup, release boundary, both adjacent migrations, exact orphan
+recovery, and real transaction lifecycle all pass serially.
+
+- [ ] **Step 6: Commit the release-lifecycle proof**
+
+```bash
+git add tests/practices/test_practice_migration_release.py
+git commit -m "test(deploy): prove practice migration rollback"
+```
+
+### Task 4: Verify, Review, Redeploy, and Resume the Approved Rollout
+
+**Files:**
+
+- No planned source changes; failures return to the owning task with a new regression test.
+- Read: `docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md`
+- Read: `docs/superpowers/plans/2026-07-16-practice-announcement-rollout.md`
+
+**Interfaces:**
+
+- Consumes the three reviewed hotfix commits and a sole Alembic head at `d8b2c6f4a901`.
+- Produces a merged hotfix, successful Render pre-deploy, canonical production schema with 30 backfilled summary identities, and a deployed Preview confirmation.
+- Produces a fresh read-only production seed digest, then stops for explicit approval; it does not seed in this task.
+
+- [ ] **Step 1: Confirm no local Slack consumer is running**
+
+```bash
+pgrep -af "gunicorn|flask run|socket_mode|practice-preview" || true
+```
+
+Expected: no local TCSC companion or web process using production Slack
+credentials. Inspect matches before acting; never stop unrelated user work.
+
+- [ ] **Step 2: Run the focused hotfix and practice migration suites**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest \
+    tests/test_app_startup.py \
+    tests/scripts/test_release.py \
+    tests/practices/test_plan_reaction_migration.py \
+    tests/practices/test_practice_summary_post_migration.py \
+    tests/practices/test_practice_migration_release.py \
+    tests/practices/test_practice_summary_posts.py \
+    tests/slack/test_practice_summary_registry.py -q
+```
+
+Expected: all focused tests pass serially with no external Slack calls.
+
+- [ ] **Step 3: Run the full Python, Node, CSS, and migration-head gates**
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest -q
+npm run test:practice-reactions
+npm run tailwind:build
+git diff --exit-code -- app/static/css/tailwind-output.css
+TCSC_MIGRATION_ONLY=1 \
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+DATABASE_URL=postgresql://tcsc:tcsc@localhost:5432/tcsc_trips \
+  env/bin/flask db heads
+git diff --check
+git status --short
+```
+
+Expected: all Python and Node tests pass, generated CSS is deterministic, the
+sole Alembic head is `d8b2c6f4a901`, diff checks are clean, and status contains
+only the pre-existing `?? env`.
+
+- [ ] **Step 4: Request independent spec and safety reviews**
+
+Review `81b92ea..HEAD` for:
+
+- exact compliance with the approved recovery spec;
+- import-time release isolation and absence of background consumers;
+- lock-before-validation ordering and fail-closed catalog checks;
+- no path that drops a populated, canonical, or malformed table;
+- transaction rollback coverage from the exact audited start state;
+- local-database and Slack side-effect safety; and
+- no unrelated refactoring.
+
+Any Critical or Important finding returns to the owning task's RED/GREEN cycle.
+Do not push with an unresolved blocker.
+
+- [ ] **Step 5: Push the hotfix and open the PR**
+
+```bash
+git push -u origin fix/practice-migration-create-all
+gh pr create \
+  --base main \
+  --head fix/practice-migration-create-all \
+  --title "Recover practice summary migration safely" \
+  --body-file \
+    docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
+```
+
+Expected: the PR contains only the committed design, hotfix, tests, and this
+plan; the untracked `env` symlink is absent.
+
+- [ ] **Step 6: Require green GitHub checks and merge once**
+
+```bash
+gh pr checks
+```
+
+Expected: all required checks pass. Poll pending checks with the product wait
+mechanism in intervals no longer than 60 seconds; never bypass a failure. Then:
+
+```bash
+gh pr merge --merge
+```
+
+Expected: the PR merges to `main` and Render starts one deployment from the new
+merge commit. Do not manually retry the old `81b92ea` deployment.
+
+- [ ] **Step 7: Observe the Render pre-deploy before checking production**
+
+Require the new deployment log to show:
+
+```text
+=== Release tasks starting ===
+Running database migrations...
+Running upgrade e36bbec59bde -> c4f1a8e2d9b7
+Running upgrade c4f1a8e2d9b7 -> d8b2c6f4a901
+=== Release tasks completed ===
+```
+
+The pre-deploy log must not contain `APScheduler started successfully`,
+`Slack Bolt enabled`, or `Socket Mode`. If pre-deploy fails, stop and inspect
+production read-only; do not stamp, manually drop, or blindly redeploy.
+
+- [ ] **Step 8: Verify the production schema and backfill read-only**
+
+Run from the repository environment without printing the connection URL:
+
+```bash
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+env/bin/python - <<'PY'
+import os
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+load_dotenv('.env')
+engine = create_engine(os.environ['PROD_DATABASE_URL'])
+with engine.connect() as connection:
+    transaction = connection.begin()
+    connection.exec_driver_sql('SET TRANSACTION READ ONLY')
+    revision = connection.execute(
+        text('SELECT version_num FROM alembic_version')
+    ).scalar_one()
+    assert revision == 'd8b2c6f4a901'
+    c4_columns = {
+        tuple(row)
+        for row in connection.execute(text('''
+            SELECT table_name, column_name
+            FROM information_schema.columns
+            WHERE table_schema = current_schema()
+              AND (table_name, column_name) IN (
+                ('practice_activities', 'default_plan_reactions'),
+                ('practice_types', 'default_plan_reactions'),
+                ('practices', 'plan_reactions'),
+                ('practices', 'slack_session_emoji')
+              )
+        '''))
+    }
+    assert c4_columns == {
+        ('practice_activities', 'default_plan_reactions'),
+        ('practice_types', 'default_plan_reactions'),
+        ('practices', 'plan_reactions'),
+        ('practices', 'slack_session_emoji'),
+    }
+    defaults = dict(connection.execute(text('''
+        SELECT column_name, column_default
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'practice_summary_posts'
+          AND column_name IN ('created_at', 'updated_at')
+    ''')).all())
+    assert defaults == {'created_at': 'now()', 'updated_at': 'now()'}
+    constraint_names = set(connection.execute(text('''
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid = 'practice_summary_posts'::regclass
+          AND contype IN ('c', 'p', 'u')
+    ''')).scalars())
+    assert constraint_names == {
+        'ck_practice_summary_post_surface',
+        'practice_summary_posts_pkey',
+        'uq_practice_summary_post_week_surface',
+    }
+    counts = connection.execute(text('''
+        SELECT surface, count(*)
+        FROM practice_summary_posts
+        GROUP BY surface
+        ORDER BY surface
+    ''')).all()
+    assert counts == [('coach_summary', 19), ('weekly_summary', 11)]
+    conflicts = connection.execute(text('''
+        SELECT week_start, surface
+        FROM practice_summary_posts
+        GROUP BY week_start, surface
+        HAVING count(*) > 1
+    ''')).all()
+    assert conflicts == []
+    cross_week_reuse = connection.execute(text('''
+        SELECT surface, message_ts
+        FROM practice_summary_posts
+        GROUP BY surface, message_ts
+        HAVING count(DISTINCT week_start) > 1
+    ''')).all()
+    assert cross_week_reuse == []
+    transaction.rollback()
+engine.dispose()
+print('production_migration_verified revision=d8b2c6f4a901 rows=30')
+PY
+```
+
+Expected: one sanitized verification line. Keep the writer-quiet window active.
+
+- [ ] **Step 9: Test Preview through Render as the sole Socket consumer**
+
+Confirm the local companion remains stopped, then ask the user to invoke:
+
+```text
+/tcsc practice-preview
+```
+
+in `C07G9RTMRT3`. The user confirms the modal opens with the approved compact
+reaction editor and Preview formatting, then discards it without creating or
+editing a practice or message. Never post to `#announcements-practices`.
+
+Only after that confirmation, tell the user practice Create/Edit may resume
+and close the writer-quiet window.
+
+- [ ] **Step 10: Generate the production seed dry run and stop for approval**
+
+```bash
+env/bin/python scripts/seed_practice_plan_reaction_defaults.py \
+  --environment production --dry-run
+```
+
+Expected: canonical target/current/desired JSON and one approval digest, with
+zero writes. Present the complete diff and exact digest to the user, state that
+production values have not changed, and stop. Do not run `--commit` without a
+fresh explicit approval of that exact digest.

--- a/docs/superpowers/plans/2026-07-17-practice-migration-create-all-recovery.md
+++ b/docs/superpowers/plans/2026-07-17-practice-migration-create-all-recovery.md
@@ -13,7 +13,7 @@
 - Alembic is the only application schema authority. Remove runtime `db.create_all()` rather than hiding it behind an environment flag.
 - Only literal `TCSC_MIGRATION_ONLY=1` suppresses background startup; normal Render web workers retain their existing scheduler and Slack behavior.
 - `scripts/release.sh` must blank `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_SIGNING_SECRET` before Python imports `app.slack.bolt_app`.
-- Recover only a permanent, row-security-disabled, exact seven-column ORM-shaped `practice_summary_posts` table with its expected serial sequence, constraints, indexes, no timestamp defaults, and zero rows.
+- Recover only a permanent, row-security-disabled, exact seven-column ORM-shaped `practice_summary_posts` table with its expected serial sequence, constraints, indexes, no timestamp defaults, no user triggers, row-security policies, or explicit publication memberships, and zero rows.
 - Acquire `ACCESS EXCLUSIVE` before fingerprint and emptiness validation and hold it through orphan replacement.
 - Any populated, canonical-looking, or structurally different pre-existing relation fails before `DROP TABLE`; errors identify invariants but never include Slack timestamps or practice data.
 - The `c4f1a8e2d9b7` changes, orphan replacement, legacy conflict checks, backfill, and revision update remain in one PostgreSQL transaction. A failure from the audited starting shape must restore the orphan, roll back all four `c4` columns, and leave revision `e36bbec59bde`.
@@ -31,9 +31,9 @@
   base tables; repairing that legacy chain remains separate work.
 - Keep `create_app()` schema-neutral despite that known local-bootstrap gap.
 - Before dropping the audited empty orphan, also reject behavior-bearing
-  attached metadata: user triggers and row-security policies. Cover each with
-  a fixed invariant error, a direct no-`drop_table` assertion, and unchanged
-  catalog state.
+  attached metadata: user triggers, row-security policies, and explicit
+  PostgreSQL publication membership. Cover each with a fixed invariant error,
+  a direct no-`drop_table` assertion, and unchanged catalog state.
 - Offline Alembic SQL generation and test-only process-group timeout cleanup
   are review Minors outside the Render online migration path and are deferred.
 

--- a/docs/superpowers/plans/2026-07-17-practice-migration-create-all-recovery.md
+++ b/docs/superpowers/plans/2026-07-17-practice-migration-create-all-recovery.md
@@ -23,6 +23,20 @@
 - Run PostgreSQL tests serially against the suite-pinned local database, with all Slack credentials explicitly blank.
 - Preserve the untracked `env` symlink and unrelated user changes.
 
+### Approved production-only review amendment (2026-07-18)
+
+- The user explicitly prioritized restoring the existing production database
+  and removed clean local-database bootstrap from this rollout's acceptance
+  criteria. The repository's historical root migration assumes pre-existing
+  base tables; repairing that legacy chain remains separate work.
+- Keep `create_app()` schema-neutral despite that known local-bootstrap gap.
+- Before dropping the audited empty orphan, also reject behavior-bearing
+  attached metadata: user triggers and row-security policies. Cover each with
+  a fixed invariant error, a direct no-`drop_table` assertion, and unchanged
+  catalog state.
+- Offline Alembic SQL generation and test-only process-group timeout cleanup
+  are review Minors outside the Render online migration path and are deferred.
+
 ---
 
 ## File Map

--- a/docs/superpowers/plans/2026-07-18-production-orphan-attached-behavior-guard.md
+++ b/docs/superpowers/plans/2026-07-18-production-orphan-attached-behavior-guard.md
@@ -1,0 +1,278 @@
+# Production Orphan Attached-Behavior Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the production migration recovery by refusing to replace an otherwise matching empty summary table when user triggers or row-security policies are attached.
+
+**Architecture:** Extend the already locked `d8` catalog fingerprint with one behavior tuple: non-internal trigger count and policy count for the captured relation OID. Both counts must be zero before `DROP TABLE`; independent PostgreSQL tests prove the fixed refusal occurs before the drop. Fresh local-database bootstrap, offline SQL generation, and test process-group cleanup remain outside this production rollout by explicit user direction.
+
+**Tech Stack:** Python 3.11+, Flask-Migrate/Alembic, SQLAlchemy 2, PostgreSQL 18, pytest, Bash, Git/GitHub, Render.
+
+## Global Constraints
+
+- Keep `create_app()` schema-neutral; do not restore runtime `db.create_all()`.
+- Do not repair or work around clean local-database bootstrap in this rollout.
+- Acquire `ACCESS EXCLUSIVE` before every orphan fingerprint query and hold it through replacement.
+- Reject user triggers and policies with a fixed invariant-only error before `op.drop_table` is called.
+- Do not include trigger names, policy names, Slack timestamps, or practice data in errors.
+- Preserve all existing exact column/default/sequence/constraint/index/dependency/row checks.
+- Run PostgreSQL tests serially against the suite-pinned localhost database with `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_SIGNING_SECRET` blank.
+- Do not access or write Slack while implementing or testing.
+- Preserve the untracked `env` symlink and unrelated user changes.
+- Defer offline Alembic SQL support and test-only process-group timeout cleanup.
+
+---
+
+### Task 1: Reject Attached Triggers and Policies Before Drop
+
+**Files:**
+
+- Modify: `migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py`
+- Modify: `tests/practices/migration_test_support.py`
+- Modify: `tests/practices/test_practice_summary_post_migration.py`
+
+**Interfaces:**
+
+- Extends `_summary_table_fingerprint(bind, relation_oid)` with `"attached_behavior": tuple[int, int]` in `(user_trigger_count, policy_count)` order.
+- Extends `summary_catalog_snapshot(connection)` with the same independent `"attached_behavior"` tuple.
+- `_assert_exact_empty_create_all_orphan(...)` raises exactly `RuntimeError("practice_summary_posts orphan recovery refused: attached behavior mismatch")` when either count is nonzero.
+
+- [ ] **Step 1: Add the independent behavior snapshot**
+
+In `summary_catalog_snapshot(...)`, after the external-dependency query and before the row-count query, add:
+
+```python
+    attached_behavior = connection.execute(text("""
+        SELECT
+          (SELECT count(*)
+           FROM pg_trigger AS trigger
+           WHERE trigger.tgrelid = :oid
+             AND NOT trigger.tgisinternal) AS user_trigger_count,
+          (SELECT count(*)
+           FROM pg_policy AS policy
+           WHERE policy.polrelid = :oid) AS policy_count
+    """), {"oid": oid}).one()
+```
+
+Add this field to the returned dictionary:
+
+```python
+        "attached_behavior": tuple(attached_behavior),
+```
+
+- [ ] **Step 2: Add trigger and policy refusal regressions**
+
+Add these tests to `tests/practices/test_practice_summary_post_migration.py`:
+
+```python
+def test_upgrade_refuses_empty_orphan_with_user_trigger_without_mutation(
+    engine,
+    monkeypatch,
+):
+    with migration_schema(engine, "summary_user_trigger") as (
+        connection,
+        _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE FUNCTION keep_summary_row()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$ BEGIN RETURN NEW; END $$
+        """)
+        connection.exec_driver_sql("""
+            CREATE TRIGGER unexpected_summary_trigger
+            BEFORE INSERT ON practice_summary_posts
+            FOR EACH ROW EXECUTE FUNCTION keep_summary_row()
+        """)
+        assert summary_catalog_snapshot(connection)[
+            "attached_behavior"
+        ] == (1, 0)
+
+        _assert_upgrade_refused_without_mutation(
+            connection,
+            monkeypatch,
+            expected_invariant="attached behavior mismatch",
+        )
+
+
+def test_upgrade_refuses_empty_orphan_with_policy_without_mutation(
+    engine,
+    monkeypatch,
+):
+    with migration_schema(engine, "summary_policy") as (
+        connection,
+        _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE POLICY unexpected_summary_policy
+            ON practice_summary_posts
+            USING (true)
+        """)
+        assert summary_catalog_snapshot(connection)[
+            "attached_behavior"
+        ] == (0, 1)
+
+        _assert_upgrade_refused_without_mutation(
+            connection,
+            monkeypatch,
+            expected_invariant="attached behavior mismatch",
+        )
+```
+
+Add `"attached behavior mismatch"` to the refusal helper's allowed invariant tuple.
+
+- [ ] **Step 3: Run the two tests and verify RED**
+
+Run:
+
+```bash
+DATABASE_URL=postgresql://tcsc:tcsc@localhost:5432/tcsc_trips \
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest tests/practices/test_practice_summary_post_migration.py \
+  -q -k 'user_trigger or policy_without_mutation'
+```
+
+Expected: both tests fail because the current fingerprint accepts the attached behavior and reaches `op.drop_table` instead of raising the fixed refusal.
+
+- [ ] **Step 4: Add the locked production fingerprint query**
+
+In `_summary_table_fingerprint(...)`, after `has_external_dependencies` and before the schema-qualified row query, add:
+
+```python
+    attached_behavior = bind.execute(sa.text("""
+        SELECT
+          (SELECT count(*)
+           FROM pg_trigger AS trigger
+           WHERE trigger.tgrelid = :oid
+             AND NOT trigger.tgisinternal) AS user_trigger_count,
+          (SELECT count(*)
+           FROM pg_policy AS policy
+           WHERE policy.polrelid = :oid) AS policy_count
+    """), {"oid": relation_oid}).one()
+```
+
+Add this field to the returned fingerprint:
+
+```python
+        "attached_behavior": tuple(attached_behavior),
+```
+
+In `_assert_exact_empty_create_all_orphan(...)`, after the external-dependency invariant and before the row invariant, add:
+
+```python
+    if fingerprint["attached_behavior"] != (0, 0):
+        _refuse_orphan_recovery("attached behavior mismatch")
+```
+
+Do not query by object name or surface any catalog values in the error.
+
+- [ ] **Step 5: Run focused GREEN and adjacent migration gates**
+
+Run:
+
+```bash
+DATABASE_URL=postgresql://tcsc:tcsc@localhost:5432/tcsc_trips \
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest tests/practices/test_practice_summary_post_migration.py -q
+```
+
+Expected: `28 passed`.
+
+Then run:
+
+```bash
+DATABASE_URL=postgresql://tcsc:tcsc@localhost:5432/tcsc_trips \
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest \
+    tests/test_app_startup.py \
+    tests/scripts/test_release.py \
+    tests/practices/test_plan_reaction_migration.py \
+    tests/practices/test_practice_summary_post_migration.py \
+    tests/practices/test_practice_migration_release.py -q
+```
+
+Expected: `36 passed`.
+
+- [ ] **Step 6: Commit the guard**
+
+```bash
+git add \
+  migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py \
+  tests/practices/migration_test_support.py \
+  tests/practices/test_practice_summary_post_migration.py
+git commit -m "fix(practices): reject attached summary behavior"
+```
+
+The commit must not include `env` or any unrelated file.
+
+### Task 2: Re-verify and Release the Production Hotfix
+
+**Files:**
+
+- Verify only: complete branch from merge base `81b92ea6e56bbdcf77ee62fa3e015d8b3285d6e2`
+- Reuse: `scripts/release.sh`
+- Reuse: `scripts/seed_practice_plan_reaction_defaults.py`
+
+**Interfaces:**
+
+- Produces a reviewed hotfix PR whose sole Alembic head is `d8b2c6f4a901`.
+- Produces an online Render pre-deploy with no scheduler, Bolt, or Socket Mode startup.
+- Leaves the production seed in dry-run mode until the user separately approves its exact digest.
+
+- [ ] **Step 1: Run fresh whole-branch gates**
+
+```bash
+DATABASE_URL=postgresql://tcsc:tcsc@localhost:5432/tcsc_trips \
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/pytest -q
+npm run test:practice-reactions
+git diff --check 81b92ea..HEAD
+bash -n scripts/release.sh
+DATABASE_URL=postgresql://tcsc:tcsc@localhost:5432/tcsc_trips \
+TCSC_MIGRATION_ONLY=1 FLASK_APP=app:create_app \
+SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
+  env/bin/flask db heads
+git status --short
+```
+
+Expected: all Python and all 51 Node tests pass; the only head is `d8b2c6f4a901`; the only untracked entry is `env`.
+
+- [ ] **Step 2: Request independent whole-branch re-review**
+
+Review `81b92ea..HEAD` against the approved recovery design and the production-only amendment. Critical and Important findings block release; local empty-database bootstrap, offline SQL generation, and test process-group cleanup are explicitly deferred and must not be reintroduced as rollout blockers.
+
+- [ ] **Step 3: Audit the production precondition read-only**
+
+In one read-only transaction, verify:
+
+```sql
+SELECT version_num FROM alembic_version;
+
+SELECT
+  (SELECT count(*)
+   FROM pg_trigger
+   WHERE tgrelid = 'public.practice_summary_posts'::regclass
+     AND NOT tgisinternal) AS user_trigger_count,
+  (SELECT count(*)
+   FROM pg_policy
+   WHERE polrelid = 'public.practice_summary_posts'::regclass) AS policy_count,
+  (SELECT count(*) FROM public.practice_summary_posts) AS row_count;
+```
+
+Expected: revision `e36bbec59bde` and all three counts zero. Stop without deploying if any value differs.
+
+- [ ] **Step 4: Merge and deploy**
+
+Push the branch, open the hotfix PR, wait for required checks, merge without rewriting commits, and deploy the merged `main` commit to `tcsc-registration`. Confirm pre-deploy logs show `e36 -> c4 -> d8`, successful release completion, and no scheduler, Bolt, or Socket Mode startup.
+
+- [ ] **Step 5: Verify production read-only after deployment**
+
+Verify revision `d8b2c6f4a901`, all four `c4` columns, canonical `now()` defaults, expected constraints, 19 coach plus 11 weekly identities, zero duplicate `(week_start, surface)` rows, and zero cross-week timestamp reuse.
+
+- [ ] **Step 6: Complete the user-operated Preview and seed gates**
+
+Ask the user to invoke `/tcsc practice-preview` in `C07G9RTMRT3`. End the writer-quiet window only after that deployed Preview succeeds. Then run the production reaction-default seed in dry-run mode, present its complete target diff and exact digest, and stop for fresh explicit approval before any seed commit.

--- a/docs/superpowers/plans/2026-07-18-production-orphan-attached-behavior-guard.md
+++ b/docs/superpowers/plans/2026-07-18-production-orphan-attached-behavior-guard.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Finish the production migration recovery by refusing to replace an otherwise matching empty summary table when user triggers or row-security policies are attached.
+**Goal:** Finish the production migration recovery by refusing to replace an otherwise matching empty summary table when user triggers, row-security policies, or explicit publication membership are attached.
 
-**Architecture:** Extend the already locked `d8` catalog fingerprint with one behavior tuple: non-internal trigger count and policy count for the captured relation OID. Both counts must be zero before `DROP TABLE`; independent PostgreSQL tests prove the fixed refusal occurs before the drop. Fresh local-database bootstrap, offline SQL generation, and test process-group cleanup remain outside this production rollout by explicit user direction.
+**Architecture:** Extend the already locked `d8` catalog fingerprint with one behavior tuple and one independent publication-membership count for the captured relation OID. The non-internal trigger count, policy count, and `pg_publication_rel` count must all be zero before `DROP TABLE`; independent PostgreSQL tests prove each fixed refusal occurs before the drop. Fresh local-database bootstrap, offline SQL generation, and test process-group cleanup remain outside this production rollout by explicit user direction.
 
 **Tech Stack:** Python 3.11+, Flask-Migrate/Alembic, SQLAlchemy 2, PostgreSQL 18, pytest, Bash, Git/GitHub, Render.
 
@@ -13,13 +13,25 @@
 - Keep `create_app()` schema-neutral; do not restore runtime `db.create_all()`.
 - Do not repair or work around clean local-database bootstrap in this rollout.
 - Acquire `ACCESS EXCLUSIVE` before every orphan fingerprint query and hold it through replacement.
-- Reject user triggers and policies with a fixed invariant-only error before `op.drop_table` is called.
-- Do not include trigger names, policy names, Slack timestamps, or practice data in errors.
+- Reject user triggers, policies, and explicit publication membership with fixed invariant-only errors before `op.drop_table` is called.
+- Do not include trigger names, policy names, publication names, catalog values, Slack timestamps, or practice data in errors.
 - Preserve all existing exact column/default/sequence/constraint/index/dependency/row checks.
 - Run PostgreSQL tests serially against the suite-pinned localhost database with `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, and `SLACK_SIGNING_SECRET` blank.
 - Do not access or write Slack while implementing or testing.
 - Preserve the untracked `env` symlink and unrelated user changes.
 - Defer offline Alembic SQL support and test-only process-group timeout cleanup.
+
+### Approved final-review amendment (2026-07-18)
+
+- Extend the independent test snapshot and locked production fingerprint with
+  `publication_membership_count`, queried by captured relation OID from
+  `pg_publication_rel.prrelid`.
+- After the trigger/policy invariant and before the row invariant, refuse any
+  nonzero membership count with exactly `practice_summary_posts orphan
+  recovery refused: publication membership mismatch`.
+- Cover one real explicit table publication with the existing no-drop and
+  unchanged-catalog helper. With no unrelated inventory change, the focused
+  migration file contains 29 tests and the adjacent hotfix set contains 37.
 
 ---
 
@@ -180,7 +192,7 @@ SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
   env/bin/pytest tests/practices/test_practice_summary_post_migration.py -q
 ```
 
-Expected: `28 passed`.
+Expected: `29 passed`.
 
 Then run:
 
@@ -195,7 +207,7 @@ SLACK_BOT_TOKEN= SLACK_APP_TOKEN= SLACK_SIGNING_SECRET= \
     tests/practices/test_practice_migration_release.py -q
 ```
 
-Expected: `36 passed`.
+Expected: `37 passed`.
 
 - [ ] **Step 6: Commit the guard**
 

--- a/docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
@@ -1,0 +1,169 @@
+# Practice Migration `create_all` Recovery Design
+
+**Date:** 2026-07-17
+**Status:** Approved in principle; awaiting written-spec review
+
+## Context
+
+Render checked out merge commit `81b92ea6e56bbdcf77ee62fa3e015d8b3285d6e2`
+and built it successfully. Its pre-deploy command, `flask db upgrade`, then
+failed while applying `d8b2c6f4a901` because `practice_summary_posts` already
+existed.
+
+The failure is deterministic:
+
+1. Flask constructs the application before running the `db upgrade` command.
+2. `create_app()` imports the practice models and unconditionally calls
+   `db.create_all()`.
+3. SQLAlchemy creates the newly modeled `practice_summary_posts` table in its
+   own committed transaction.
+4. Alembic starts afterward and attempts to create the same table.
+
+The failed Alembic transaction rolled back cleanly. Production remains at
+`e36bbec59bde`; none of the four `c4f1a8e2d9b7` columns exists. The orphan
+summary table is empty. Its columns and constraints match the ORM model, while
+`created_at` and `updated_at` lack the `now()` server defaults required by
+`d8`. This fingerprint confirms that `db.create_all()`, not Alembic, created
+it.
+
+## Goals
+
+- Make Alembic the only application schema authority.
+- Recover the one known empty ORM-created orphan transactionally.
+- Fail closed for any pre-existing table that is populated or structurally
+  different.
+- Exercise the actual Flask/Alembic release lifecycle before redeployment.
+- Complete the already-approved deployment without manual production DDL or
+  revision stamping.
+
+## Non-goals
+
+- General-purpose migration repair for arbitrary database drift.
+- Preserving data from an unexpected populated summary table.
+- Adding retries, an outbox, maintenance mode, or a new deployment framework.
+- Changing practice announcement, reaction, or authoring behavior.
+
+## Design
+
+### 1. Alembic becomes the schema authority
+
+Remove the unconditional `db.create_all()` call from `create_app()`.
+Application and Flask CLI startup must never create or alter schema objects.
+New local databases must be initialized with `flask db upgrade`; tests that
+own disposable schemas may continue to call `db.create_all()` explicitly in
+their fixtures.
+
+This is preferred over an environment flag in `scripts/release.sh`. A flag
+would protect only one command while leaving web startup, Flask shell, and
+other CLI commands able to mutate production schema before Alembic.
+
+### 2. Pre-deploy starts no background consumers
+
+`scripts/release.sh` runs the Flask migration command with
+`TCSC_MIGRATION_ONLY=1` and explicitly blank Slack bot, app, and signing
+credentials. `create_app()` still registers the Flask-Migrate extension, but
+skips `init_scheduler()` when that flag is set. Because the credentials are
+blank before Python imports the Slack module, the pre-deploy process cannot
+initialize Bolt or Socket Mode either.
+
+The flag affects process startup only; it never creates, alters, or bypasses
+schema. Normal Render web workers retain the existing scheduler and Slack
+behavior.
+
+### 3. `d8` adopts only the exact empty orphan fingerprint
+
+Before creating `practice_summary_posts`, migration `d8b2c6f4a901` checks
+whether the relation already exists.
+
+If it does not exist, the migration follows its normal create, validate, and
+backfill path.
+
+If it exists, the migration validates all of the following before mutation:
+
+- it is a permanent ordinary table in the migration's target schema, with row
+  security disabled;
+- its column names, order, SQL types, and nullability match the ORM-created
+  table;
+- its `id` default and owned sequence match the ORM-created serial primary key,
+  while the remaining non-timestamp columns have no defaults;
+- its primary key, named `(week_start, surface)` unique constraint, named
+  surface check constraint, indexes, and lack of foreign keys match;
+- `created_at` and `updated_at` have no server defaults, distinguishing the
+  ORM-created shape from the canonical Alembic shape; and
+- it contains zero rows.
+
+The migration acquires an `ACCESS EXCLUSIVE` lock on the existing relation
+before fingerprint or row validation and holds it through replacement. This
+prevents a concurrent process from adding a row after the zero-row check. If
+the relation cannot be locked as the expected table, recovery fails without
+mutation.
+
+Only that exact fingerprint is recoverable. The migration drops the empty
+orphan and recreates the canonical table with Alembic's `now()` server
+defaults. It then runs the existing same-week and cross-week legacy conflict
+checks and performs the normal backfill.
+
+Any populated table, canonical-looking table, malformed table, unexpected
+constraint/index, or relation in another shape raises a clear migration error
+before the table is dropped. The error reports the failed invariant without
+including Slack timestamps or practice data.
+
+### 4. Transaction boundary
+
+The orphan validation, drop, canonical create, legacy conflict checks,
+backfill, and Alembic version update all execute inside Alembic's PostgreSQL
+transaction. If any step fails, PostgreSQL restores the original empty orphan
+and leaves the database at `e36bbec59bde`.
+
+Migration `c4` remains immediately before `d8` in that same upgrade. A
+successful release therefore atomically produces the reaction columns, the
+canonical summary table, its legacy backfill, and revision
+`d8b2c6f4a901`.
+
+## Testing
+
+Tests must be written and observed failing before production changes.
+
+Required coverage:
+
+1. Application startup does not call `db.create_all()`.
+2. Migration-only startup suppresses the scheduler, Bolt, and Socket Mode;
+   the release command supplies the migration-only flag and blank credentials.
+3. A normal pre-`d8` schema with no summary table upgrades successfully.
+4. An exact empty ORM-shaped orphan is locked and adopted, yielding canonical
+   timestamp defaults and the expected legacy backfill.
+5. A non-empty orphan fails closed and remains unchanged.
+6. A structurally different or canonical-looking pre-existing table fails
+   closed and remains unchanged.
+7. The actual Flask CLI release sequence starts at revision `e36bbec59bde`
+   with no `c4` columns and the exact empty orphan, then reaches the sole
+   Alembic head without pre-Alembic schema creation or background consumers.
+8. From that same audited starting shape, a forced post-replacement failure
+   restores the orphan definition, rolls back all `c4` columns, and leaves the
+   Alembic revision at `e36bbec59bde`.
+9. Migration downgrade/upgrade coverage, focused practice tests, and the full
+   Python suite remain green.
+
+All local Flask and test commands explicitly blank Slack credentials. No test
+may initialize the application against production.
+
+## Rollout
+
+1. Implement and independently review the hotfix on a branch from merged
+   `main`.
+2. Run focused migration tests, the real release-lifecycle regression, the
+   full Python suite, and the existing Node/Tailwind gates.
+3. Merge a small hotfix PR.
+4. Redeploy `tcsc-registration`; do not manually drop or stamp anything.
+   Confirm pre-deploy logs contain no scheduler, Bolt, or Socket Mode startup.
+5. Verify production revision `d8b2c6f4a901`, all four `c4` columns, canonical
+   summary-table defaults/constraints, exactly 30 backfilled identities, and
+   zero week/surface conflicts.
+6. Test `/tcsc practice-preview` through Render in `C07G9RTMRT3` as the sole
+   Socket Mode consumer.
+7. End the practice-writer quiet window only after the deployed Preview passes.
+8. Run the production seed dry run and stop for fresh digest approval.
+
+If pre-deploy fails again, the old production service remains live. Stop and
+inspect read-only state; never stamp a revision or repeat a commit whose
+post-commit verification is unknown.

--- a/docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
@@ -42,6 +42,10 @@ it.
 - Preserving data from an unexpected populated summary table.
 - Adding retries, an outbox, maintenance mode, or a new deployment framework.
 - Changing practice announcement, reaction, or authoring behavior.
+- Repairing the historical migration root so a brand-new empty local database
+  can reach head. The existing production database is already versioned at
+  `e36bbec59bde`; empty-database bootstrap is separate legacy work and is not a
+  gate for this production recovery.
 
 ## Design
 
@@ -49,9 +53,11 @@ it.
 
 Remove the unconditional `db.create_all()` call from `create_app()`.
 Application and Flask CLI startup must never create or alter schema objects.
-New local databases must be initialized with `flask db upgrade`; tests that
-own disposable schemas may continue to call `db.create_all()` explicitly in
-their fixtures.
+This recovery targets existing versioned databases, including production.
+Tests that own disposable schemas may continue to call `db.create_all()`
+explicitly in their fixtures. The repository's pre-existing incomplete root
+migration means clean local bootstrap requires separate follow-up work; this
+hotfix does not reintroduce runtime schema creation to mask that legacy gap.
 
 This is preferred over an environment flag in `scripts/release.sh`. A flag
 would protect only one command while leaving web startup, Flask shell, and
@@ -88,6 +94,7 @@ If it exists, the migration validates all of the following before mutation:
   while the remaining non-timestamp columns have no defaults;
 - its primary key, named `(week_start, surface)` unique constraint, named
   surface check constraint, indexes, and lack of foreign keys match;
+- it has no user triggers or row-security policies attached to it;
 - `created_at` and `updated_at` have no server defaults, distinguishing the
   ORM-created shape from the canonical Alembic shape; and
 - it contains zero rows.

--- a/docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
@@ -1,7 +1,7 @@
 # Practice Migration `create_all` Recovery Design
 
 **Date:** 2026-07-17
-**Status:** Approved in principle; awaiting written-spec review
+**Status:** Approved
 
 ## Context
 

--- a/docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-17-practice-migration-create-all-recovery-design.md
@@ -94,7 +94,8 @@ If it exists, the migration validates all of the following before mutation:
   while the remaining non-timestamp columns have no defaults;
 - its primary key, named `(week_start, surface)` unique constraint, named
   surface check constraint, indexes, and lack of foreign keys match;
-- it has no user triggers or row-security policies attached to it;
+- it has no user triggers, row-security policies, or explicit PostgreSQL
+  publication memberships attached to it;
 - `created_at` and `updated_at` have no server defaults, distinguishing the
   ORM-created shape from the canonical Alembic shape; and
 - it contains zero rows.

--- a/migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py
+++ b/migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py
@@ -242,6 +242,16 @@ def _summary_table_fingerprint(bind, relation_oid):
               )
         )
     """), {"oid": relation_oid}).scalar_one()
+    attached_behavior = bind.execute(sa.text("""
+        SELECT
+          (SELECT count(*)
+           FROM pg_trigger AS trigger
+           WHERE trigger.tgrelid = :oid
+             AND NOT trigger.tgisinternal) AS user_trigger_count,
+          (SELECT count(*)
+           FROM pg_policy AS policy
+           WHERE policy.polrelid = :oid) AS policy_count
+    """), {"oid": relation_oid}).one()
     qualified = _qualified_summary_table(bind, relation["schema_name"])
     has_rows = bind.exec_driver_sql(
         f"SELECT EXISTS (SELECT 1 FROM {qualified} LIMIT 1)"
@@ -264,6 +274,7 @@ def _summary_table_fingerprint(bind, relation_oid):
         ),
         "sequence": [tuple(row) for row in sequence],
         "has_external_dependencies": has_external_dependencies,
+        "attached_behavior": tuple(attached_behavior),
         "has_rows": has_rows,
     }
 
@@ -305,6 +316,8 @@ def _assert_exact_empty_create_all_orphan(bind, relation_oid):
         _refuse_orphan_recovery("index mismatch")
     if fingerprint["has_external_dependencies"] is not False:
         _refuse_orphan_recovery("external dependency mismatch")
+    if fingerprint["attached_behavior"] != (0, 0):
+        _refuse_orphan_recovery("attached behavior mismatch")
     if fingerprint["has_rows"]:
         _refuse_orphan_recovery("table contains rows")
 

--- a/migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py
+++ b/migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py
@@ -226,6 +226,22 @@ def _summary_table_fingerprint(bind, relation_oid):
                  default_dep.refclassid, default_dep.refobjsubid,
                  default_dep.deptype
     """), {"oid": relation_oid}).all()
+    has_external_dependencies = bind.execute(sa.text("""
+        SELECT EXISTS (
+            SELECT 1
+            FROM pg_depend AS dependency
+            LEFT JOIN pg_constraint AS dependent_constraint
+              ON dependency.classid = 'pg_constraint'::regclass
+             AND dependent_constraint.oid = dependency.objid
+            WHERE dependency.refclassid = 'pg_class'::regclass
+              AND dependency.refobjid = :oid
+              AND dependency.deptype = 'n'
+              AND NOT (
+                dependency.classid = 'pg_constraint'::regclass
+                AND dependent_constraint.conrelid = :oid
+              )
+        )
+    """), {"oid": relation_oid}).scalar_one()
     qualified = _qualified_summary_table(bind, relation["schema_name"])
     has_rows = bind.exec_driver_sql(
         f"SELECT EXISTS (SELECT 1 FROM {qualified} LIMIT 1)"
@@ -247,6 +263,7 @@ def _summary_table_fingerprint(bind, relation_oid):
             for row in indexes
         ),
         "sequence": [tuple(row) for row in sequence],
+        "has_external_dependencies": has_external_dependencies,
         "has_rows": has_rows,
     }
 
@@ -286,6 +303,8 @@ def _assert_exact_empty_create_all_orphan(bind, relation_oid):
         _refuse_orphan_recovery("constraint mismatch")
     if fingerprint["indexes"] != _EXPECTED_INDEXES:
         _refuse_orphan_recovery("index mismatch")
+    if fingerprint["has_external_dependencies"] is not False:
+        _refuse_orphan_recovery("external dependency mismatch")
     if fingerprint["has_rows"]:
         _refuse_orphan_recovery("table contains rows")
 

--- a/migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py
+++ b/migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py
@@ -252,6 +252,11 @@ def _summary_table_fingerprint(bind, relation_oid):
            FROM pg_policy AS policy
            WHERE policy.polrelid = :oid) AS policy_count
     """), {"oid": relation_oid}).one()
+    publication_membership_count = bind.execute(sa.text("""
+        SELECT count(*)
+        FROM pg_publication_rel AS publication_relation
+        WHERE publication_relation.prrelid = :oid
+    """), {"oid": relation_oid}).scalar_one()
     qualified = _qualified_summary_table(bind, relation["schema_name"])
     has_rows = bind.exec_driver_sql(
         f"SELECT EXISTS (SELECT 1 FROM {qualified} LIMIT 1)"
@@ -275,6 +280,7 @@ def _summary_table_fingerprint(bind, relation_oid):
         "sequence": [tuple(row) for row in sequence],
         "has_external_dependencies": has_external_dependencies,
         "attached_behavior": tuple(attached_behavior),
+        "publication_membership_count": publication_membership_count,
         "has_rows": has_rows,
     }
 
@@ -318,6 +324,8 @@ def _assert_exact_empty_create_all_orphan(bind, relation_oid):
         _refuse_orphan_recovery("external dependency mismatch")
     if fingerprint["attached_behavior"] != (0, 0):
         _refuse_orphan_recovery("attached behavior mismatch")
+    if fingerprint["publication_membership_count"] != 0:
+        _refuse_orphan_recovery("publication membership mismatch")
     if fingerprint["has_rows"]:
         _refuse_orphan_recovery("table contains rows")
 

--- a/migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py
+++ b/migrations/versions/d8b2c6f4a901_add_practice_summary_posts.py
@@ -13,8 +13,298 @@ down_revision = "c4f1a8e2d9b7"
 branch_labels = None
 depends_on = None
 
+SUMMARY_TABLE = "practice_summary_posts"
+_EXPECTED_ID_DEFAULT = (
+    "nextval('practice_summary_posts_id_seq'::regclass)"
+)
+
+_EXPECTED_COLUMN_SHAPE = (
+    (1, "id", "integer", True, "", ""),
+    (2, "week_start", "date", True, "", ""),
+    (3, "surface", "character varying(32)", True, "", ""),
+    (4, "channel_id", "character varying(50)", False, "", ""),
+    (5, "message_ts", "character varying(50)", True, "", ""),
+    (6, "created_at", "timestamp without time zone", True, "", ""),
+    (7, "updated_at", "timestamp without time zone", True, "", ""),
+)
+
+_EXPECTED_CONSTRAINTS = (
+    (
+        "ck_practice_summary_post_surface",
+        "c",
+        ("surface",),
+        "CHECK (surface::text = ANY (ARRAY['coach_summary'::character "
+        "varying, 'weekly_summary'::character varying]::text[]))",
+    ),
+    (
+        "practice_summary_posts_pkey",
+        "p",
+        ("id",),
+        "PRIMARY KEY (id)",
+    ),
+    (
+        "uq_practice_summary_post_week_surface",
+        "u",
+        ("week_start", "surface"),
+        "UNIQUE (week_start, surface)",
+    ),
+)
+
+_EXPECTED_INDEXES = (
+    (
+        "practice_summary_posts_pkey", True, True, True, True,
+        "btree", 1, 1,
+        ("id",), None, None,
+    ),
+    (
+        "uq_practice_summary_post_week_surface", False, True, True, True,
+        "btree", 2, 2,
+        ("week_start", "surface"), None, None,
+    ),
+)
+
+
+def _refuse_orphan_recovery(invariant):
+    raise RuntimeError(
+        "practice_summary_posts orphan recovery refused: " + invariant
+    )
+
+
+def _visible_summary_relation(bind):
+    row = bind.execute(sa.text("""
+        SELECT c.oid, n.nspname AS schema_name, c.relkind,
+               c.relpersistence, c.relispartition,
+               c.relrowsecurity, c.relforcerowsecurity,
+               EXISTS (
+                 SELECT 1 FROM pg_inherits AS inheritance
+                 WHERE inheritance.inhrelid = c.oid
+               ) AS has_parent
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relname = :table_name
+    """), {"table_name": SUMMARY_TABLE}).mappings().one_or_none()
+    return dict(row) if row is not None else None
+
+
+def _visible_summary_table_oid(bind):
+    relation = _visible_summary_relation(bind)
+    return None if relation is None else relation["oid"]
+
+
+def _qualified_summary_table(bind, schema_name):
+    quote = bind.dialect.identifier_preparer.quote
+    return f"{quote(schema_name)}.{quote(SUMMARY_TABLE)}"
+
+
+def _lock_existing_summary_table(bind, relation_oid):
+    relation = _visible_summary_relation(bind)
+    if relation is None or relation["oid"] != relation_oid:
+        _refuse_orphan_recovery("relation changed before lock")
+    qualified = _qualified_summary_table(
+        bind,
+        relation["schema_name"],
+    )
+    try:
+        bind.exec_driver_sql(
+            f"LOCK TABLE {qualified} IN ACCESS EXCLUSIVE MODE"
+        )
+    except sa.exc.DBAPIError as error:
+        raise RuntimeError(
+            "practice_summary_posts orphan recovery refused: "
+            "relation could not be locked"
+        ) from error
+    locked = _visible_summary_relation(bind)
+    if locked is None or locked["oid"] != relation_oid:
+        _refuse_orphan_recovery("relation changed while acquiring lock")
+    return relation_oid
+
+
+def _summary_table_fingerprint(bind, relation_oid):
+    relation = _visible_summary_relation(bind)
+    if relation is None or relation["oid"] != relation_oid:
+        _refuse_orphan_recovery("locked relation is no longer visible")
+    columns = bind.execute(sa.text("""
+        SELECT a.attnum, a.attname,
+               format_type(a.atttypid, a.atttypmod) AS sql_type,
+               a.attnotnull, a.attidentity, a.attgenerated,
+               pg_get_expr(d.adbin, d.adrelid) AS default_expr
+        FROM pg_attribute AS a
+        LEFT JOIN pg_attrdef AS d
+          ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+        WHERE a.attrelid = :oid
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY a.attnum
+    """), {"oid": relation_oid}).all()
+    # PostgreSQL 18 also exposes generated NOT NULL constraints as contype
+    # "n". attnotnull above is the cross-version semantic fingerprint, so
+    # version-generated NOT NULL constraint names are deliberately excluded.
+    constraints = bind.execute(sa.text("""
+        SELECT con.conname, con.contype,
+               coalesce(
+                 array_agg(a.attname ORDER BY key.ord)
+                   FILTER (WHERE a.attname IS NOT NULL),
+                 ARRAY[]::name[]
+               ) AS columns,
+               pg_get_constraintdef(con.oid, true) AS definition
+        FROM pg_constraint AS con
+        LEFT JOIN LATERAL
+          unnest(con.conkey) WITH ORDINALITY AS key(attnum, ord) ON true
+        LEFT JOIN pg_attribute AS a
+          ON a.attrelid = con.conrelid AND a.attnum = key.attnum
+        WHERE con.conrelid = :oid
+          AND con.contype IN ('c', 'p', 'u', 'f', 'x')
+        GROUP BY con.oid, con.conname, con.contype
+        ORDER BY con.conname
+    """), {"oid": relation_oid}).all()
+    indexes = bind.execute(sa.text("""
+        SELECT idx.relname, ind.indisprimary, ind.indisunique,
+               ind.indisvalid, ind.indisready,
+               am.amname, ind.indnkeyatts, ind.indnatts,
+               array_agg(a.attname ORDER BY key.ord) AS columns,
+               pg_get_expr(ind.indpred, ind.indrelid) AS predicate,
+               pg_get_expr(ind.indexprs, ind.indrelid) AS expressions
+        FROM pg_index AS ind
+        JOIN pg_class AS idx ON idx.oid = ind.indexrelid
+        JOIN pg_am AS am ON am.oid = idx.relam
+        JOIN LATERAL
+          unnest(ind.indkey::smallint[]) WITH ORDINALITY
+          AS key(attnum, ord) ON true
+        LEFT JOIN pg_attribute AS a
+          ON a.attrelid = ind.indrelid AND a.attnum = key.attnum
+        WHERE ind.indrelid = :oid
+        GROUP BY idx.relname, ind.indisprimary, ind.indisunique,
+                 ind.indisvalid, ind.indisready,
+                 am.amname, ind.indnkeyatts, ind.indnatts,
+                 ind.indpred, ind.indexprs, ind.indrelid
+        ORDER BY idx.relname
+    """), {"oid": relation_oid}).all()
+    sequence = bind.execute(sa.text("""
+        SELECT seq_ns.nspname, seq.relname,
+               ownership.classid::regclass::text,
+               ownership.objsubid,
+               ownership.refclassid::regclass::text,
+               ownership.refobjsubid,
+               ownership.deptype,
+               default_dep.classid::regclass::text,
+               default_dep.objsubid,
+               default_dep.refclassid::regclass::text,
+               default_dep.refobjsubid,
+               default_dep.deptype
+        FROM pg_class AS table_rel
+        JOIN pg_attribute AS id_column
+          ON id_column.attrelid = table_rel.oid
+         AND id_column.attname = 'id'
+        JOIN pg_attrdef AS id_default
+          ON id_default.adrelid = table_rel.oid
+         AND id_default.adnum = id_column.attnum
+        JOIN pg_depend AS ownership
+          ON ownership.classid = 'pg_class'::regclass
+         AND ownership.objsubid = 0
+         AND ownership.refclassid = 'pg_class'::regclass
+         AND ownership.refobjid = table_rel.oid
+         AND ownership.refobjsubid = id_column.attnum
+         AND ownership.deptype = 'a'
+        JOIN pg_class AS seq
+          ON seq.oid = ownership.objid AND seq.relkind = 'S'
+        JOIN pg_namespace AS seq_ns ON seq_ns.oid = seq.relnamespace
+        JOIN pg_depend AS default_dep
+          ON default_dep.classid = 'pg_attrdef'::regclass
+         AND default_dep.objid = id_default.oid
+         AND default_dep.objsubid = 0
+         AND default_dep.refclassid = 'pg_class'::regclass
+         AND default_dep.refobjid = seq.oid
+         AND default_dep.refobjsubid = 0
+         AND default_dep.deptype = 'n'
+        WHERE table_rel.oid = :oid
+        ORDER BY seq_ns.nspname, seq.relname,
+                 ownership.classid, ownership.objsubid,
+                 ownership.refclassid, ownership.refobjsubid,
+                 ownership.deptype,
+                 default_dep.classid, default_dep.objsubid,
+                 default_dep.refclassid, default_dep.refobjsubid,
+                 default_dep.deptype
+    """), {"oid": relation_oid}).all()
+    qualified = _qualified_summary_table(bind, relation["schema_name"])
+    has_rows = bind.exec_driver_sql(
+        f"SELECT EXISTS (SELECT 1 FROM {qualified} LIMIT 1)"
+    ).scalar_one()
+    return {
+        "relation": (
+            relation["relkind"], relation["relpersistence"],
+            relation["relispartition"], relation["has_parent"],
+            relation["relrowsecurity"], relation["relforcerowsecurity"],
+        ),
+        "schema": relation["schema_name"],
+        "columns": [tuple(row) for row in columns],
+        "constraints": tuple(
+            (row[0], row[1], tuple(row[2]), " ".join(row[3].split()))
+            for row in constraints
+        ),
+        "indexes": tuple(
+            (*tuple(row[:8]), tuple(row[8]), row[9], row[10])
+            for row in indexes
+        ),
+        "sequence": [tuple(row) for row in sequence],
+        "has_rows": has_rows,
+    }
+
+
+def _assert_exact_empty_create_all_orphan(bind, relation_oid):
+    fingerprint = _summary_table_fingerprint(bind, relation_oid)
+    if fingerprint["relation"] != (
+        "r", "p", False, False, False, False,
+    ):
+        _refuse_orphan_recovery("relation metadata mismatch")
+    columns = fingerprint["columns"]
+    shape = tuple(row[:6] for row in columns)
+    if shape != _EXPECTED_COLUMN_SHAPE:
+        _refuse_orphan_recovery("column shape mismatch")
+    id_default = columns[0][6]
+    if id_default != _EXPECTED_ID_DEFAULT:
+        _refuse_orphan_recovery("id serial default mismatch")
+    if any(row[6] is not None for row in columns[1:]):
+        _refuse_orphan_recovery("non-id column default mismatch")
+    expected_sequence = [(
+        fingerprint["schema"],
+        "practice_summary_posts_id_seq",
+        "pg_class",
+        0,
+        "pg_class",
+        1,
+        "a",
+        "pg_attrdef",
+        0,
+        "pg_class",
+        0,
+        "n",
+    )]
+    if fingerprint["sequence"] != expected_sequence:
+        _refuse_orphan_recovery("owned serial sequence mismatch")
+    if fingerprint["constraints"] != _EXPECTED_CONSTRAINTS:
+        _refuse_orphan_recovery("constraint mismatch")
+    if fingerprint["indexes"] != _EXPECTED_INDEXES:
+        _refuse_orphan_recovery("index mismatch")
+    if fingerprint["has_rows"]:
+        _refuse_orphan_recovery("table contains rows")
+
+
+def _drop_exact_empty_create_all_orphan_if_present(bind):
+    relation_oid = _visible_summary_table_oid(bind)
+    if relation_oid is None:
+        return False
+    _lock_existing_summary_table(bind, relation_oid)
+    _assert_exact_empty_create_all_orphan(bind, relation_oid)
+    locked = _visible_summary_relation(bind)
+    if locked is None or locked["oid"] != relation_oid:
+        _refuse_orphan_recovery("locked relation is no longer visible")
+    op.drop_table(SUMMARY_TABLE, schema=locked["schema_name"])
+    return True
+
 
 def upgrade():
+    _drop_exact_empty_create_all_orphan_if_present(op.get_bind())
     op.create_table(
         "practice_summary_posts",
         sa.Column("id", sa.Integer(), primary_key=True),

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -6,6 +6,11 @@ echo "=== Release tasks starting ==="
 echo "Timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
 
 echo "Running database migrations..."
-flask db upgrade
+env \
+  TCSC_MIGRATION_ONLY=1 \
+  SLACK_BOT_TOKEN= \
+  SLACK_APP_TOKEN= \
+  SLACK_SIGNING_SECRET= \
+  flask db upgrade
 
 echo "=== Release tasks completed ==="

--- a/tests/practices/migration_test_support.py
+++ b/tests/practices/migration_test_support.py
@@ -130,6 +130,16 @@ def summary_catalog_snapshot(connection):
             AND dependent_constraint.conrelid = :oid
           )
     """), {"oid": oid}).scalar_one()
+    attached_behavior = connection.execute(text("""
+        SELECT
+          (SELECT count(*)
+           FROM pg_trigger AS trigger
+           WHERE trigger.tgrelid = :oid
+             AND NOT trigger.tgisinternal) AS user_trigger_count,
+          (SELECT count(*)
+           FROM pg_policy AS policy
+           WHERE policy.polrelid = :oid) AS policy_count
+    """), {"oid": oid}).one()
     quote = connection.dialect.identifier_preparer.quote
     qualified = (
         f"{quote(relation['schema_name'])}."
@@ -157,5 +167,6 @@ def summary_catalog_snapshot(connection):
         ],
         "sequence": [tuple(row) for row in sequence],
         "external_dependency_count": external_dependency_count,
+        "attached_behavior": tuple(attached_behavior),
         "row_count": row_count,
     }

--- a/tests/practices/migration_test_support.py
+++ b/tests/practices/migration_test_support.py
@@ -1,0 +1,146 @@
+from sqlalchemy import text
+
+from app.practices.models import PracticeSummaryPost
+
+
+def create_exact_summary_orphan(connection):
+    """Create only the ORM table in the active test schema."""
+    PracticeSummaryPost.__table__.create(connection)
+
+
+def summary_catalog_snapshot(connection):
+    relation = connection.execute(text("""
+        SELECT c.oid, n.nspname AS schema_name,
+               c.relkind, c.relpersistence, c.relispartition,
+               c.relrowsecurity, c.relforcerowsecurity,
+               EXISTS (
+                 SELECT 1 FROM pg_inherits AS inheritance
+                 WHERE inheritance.inhrelid = c.oid
+               ) AS has_parent
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relname = 'practice_summary_posts'
+    """)).mappings().one_or_none()
+    if relation is None:
+        return None
+    oid = relation["oid"]
+    columns = connection.execute(text("""
+        SELECT a.attnum, a.attname,
+               format_type(a.atttypid, a.atttypmod) AS sql_type,
+               a.attnotnull, a.attidentity, a.attgenerated,
+               pg_get_expr(d.adbin, d.adrelid) AS default_expr
+        FROM pg_attribute AS a
+        LEFT JOIN pg_attrdef AS d
+          ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+        WHERE a.attrelid = :oid
+          AND a.attnum > 0
+          AND NOT a.attisdropped
+        ORDER BY a.attnum
+    """), {"oid": oid}).all()
+    constraints = connection.execute(text("""
+        SELECT con.conname, con.contype,
+               coalesce(
+                 array_agg(a.attname ORDER BY key.ord)
+                   FILTER (WHERE a.attname IS NOT NULL),
+                 ARRAY[]::name[]
+               ) AS columns,
+               pg_get_constraintdef(con.oid, true) AS definition,
+               con.conislocal, con.coninhcount, con.connoinherit
+        FROM pg_constraint AS con
+        LEFT JOIN LATERAL
+          unnest(con.conkey) WITH ORDINALITY AS key(attnum, ord) ON true
+        LEFT JOIN pg_attribute AS a
+          ON a.attrelid = con.conrelid AND a.attnum = key.attnum
+        WHERE con.conrelid = :oid
+          AND con.contype IN ('c', 'n', 'p', 'u', 'f', 'x')
+        GROUP BY con.oid, con.conname, con.contype
+        ORDER BY con.conname
+    """), {"oid": oid}).all()
+    indexes = connection.execute(text("""
+        SELECT idx.relname, ind.indisprimary, ind.indisunique,
+               ind.indisvalid, ind.indisready,
+               am.amname, ind.indnkeyatts, ind.indnatts,
+               array_agg(a.attname ORDER BY key.ord) AS columns,
+               pg_get_expr(ind.indpred, ind.indrelid) AS predicate,
+               pg_get_expr(ind.indexprs, ind.indrelid) AS expressions
+        FROM pg_index AS ind
+        JOIN pg_class AS idx ON idx.oid = ind.indexrelid
+        JOIN pg_am AS am ON am.oid = idx.relam
+        JOIN LATERAL
+          unnest(ind.indkey::smallint[]) WITH ORDINALITY
+          AS key(attnum, ord) ON true
+        LEFT JOIN pg_attribute AS a
+          ON a.attrelid = ind.indrelid AND a.attnum = key.attnum
+        WHERE ind.indrelid = :oid
+        GROUP BY idx.relname, ind.indisprimary, ind.indisunique,
+                 ind.indisvalid, ind.indisready,
+                 am.amname, ind.indnkeyatts, ind.indnatts,
+                 ind.indpred, ind.indexprs, ind.indrelid
+        ORDER BY idx.relname
+    """), {"oid": oid}).all()
+    sequence = connection.execute(text("""
+        SELECT seq_ns.nspname, seq.relname,
+               ownership.classid::regclass::text,
+               ownership.objsubid,
+               ownership.refclassid::regclass::text,
+               ownership.refobjsubid,
+               ownership.deptype,
+               default_dep.classid::regclass::text,
+               default_dep.objsubid,
+               default_dep.refclassid::regclass::text,
+               default_dep.refobjsubid,
+               default_dep.deptype
+        FROM pg_class AS table_rel
+        JOIN pg_attribute AS id_column
+          ON id_column.attrelid = table_rel.oid
+         AND id_column.attname = 'id'
+        JOIN pg_attrdef AS id_default
+          ON id_default.adrelid = table_rel.oid
+         AND id_default.adnum = id_column.attnum
+        JOIN pg_depend AS ownership
+          ON ownership.refobjid = table_rel.oid
+         AND ownership.refobjsubid = id_column.attnum
+        JOIN pg_class AS seq
+          ON seq.oid = ownership.objid AND seq.relkind = 'S'
+        JOIN pg_namespace AS seq_ns ON seq_ns.oid = seq.relnamespace
+        JOIN pg_depend AS default_dep
+          ON default_dep.objid = id_default.oid
+         AND default_dep.refobjid = seq.oid
+        WHERE table_rel.oid = :oid
+        ORDER BY seq_ns.nspname, seq.relname,
+                 ownership.classid, ownership.objsubid,
+                 ownership.refclassid, ownership.refobjsubid,
+                 ownership.deptype,
+                 default_dep.classid, default_dep.objsubid,
+                 default_dep.refclassid, default_dep.refobjsubid,
+                 default_dep.deptype
+    """), {"oid": oid}).all()
+    quote = connection.dialect.identifier_preparer.quote
+    qualified = (
+        f"{quote(relation['schema_name'])}."
+        f"{quote('practice_summary_posts')}"
+    )
+    row_count = connection.exec_driver_sql(
+        f"SELECT count(*) FROM {qualified}"
+    ).scalar_one()
+    return {
+        "relation": tuple(relation[key] for key in (
+            "relkind", "relpersistence", "relispartition", "has_parent",
+            "relrowsecurity", "relforcerowsecurity",
+        )),
+        "columns": [tuple(row) for row in columns],
+        "constraints": [
+            (
+                row[0], row[1], tuple(row[2]), " ".join(row[3].split()),
+                row[4], row[5], row[6],
+            )
+            for row in constraints
+        ],
+        "indexes": [
+            (*tuple(row[:8]), tuple(row[8]), row[9], row[10])
+            for row in indexes
+        ],
+        "sequence": [tuple(row) for row in sequence],
+        "row_count": row_count,
+    }

--- a/tests/practices/migration_test_support.py
+++ b/tests/practices/migration_test_support.py
@@ -140,6 +140,11 @@ def summary_catalog_snapshot(connection):
            FROM pg_policy AS policy
            WHERE policy.polrelid = :oid) AS policy_count
     """), {"oid": oid}).one()
+    publication_membership_count = connection.execute(text("""
+        SELECT count(*)
+        FROM pg_publication_rel AS publication_relation
+        WHERE publication_relation.prrelid = :oid
+    """), {"oid": oid}).scalar_one()
     quote = connection.dialect.identifier_preparer.quote
     qualified = (
         f"{quote(relation['schema_name'])}."
@@ -168,5 +173,6 @@ def summary_catalog_snapshot(connection):
         "sequence": [tuple(row) for row in sequence],
         "external_dependency_count": external_dependency_count,
         "attached_behavior": tuple(attached_behavior),
+        "publication_membership_count": publication_membership_count,
         "row_count": row_count,
     }

--- a/tests/practices/migration_test_support.py
+++ b/tests/practices/migration_test_support.py
@@ -116,6 +116,20 @@ def summary_catalog_snapshot(connection):
                  default_dep.refclassid, default_dep.refobjsubid,
                  default_dep.deptype
     """), {"oid": oid}).all()
+    external_dependency_count = connection.execute(text("""
+        SELECT count(*)
+        FROM pg_depend AS dependency
+        LEFT JOIN pg_constraint AS dependent_constraint
+          ON dependency.classid = 'pg_constraint'::regclass
+         AND dependent_constraint.oid = dependency.objid
+        WHERE dependency.refclassid = 'pg_class'::regclass
+          AND dependency.refobjid = :oid
+          AND dependency.deptype = 'n'
+          AND NOT (
+            dependency.classid = 'pg_constraint'::regclass
+            AND dependent_constraint.conrelid = :oid
+          )
+    """), {"oid": oid}).scalar_one()
     quote = connection.dialect.identifier_preparer.quote
     qualified = (
         f"{quote(relation['schema_name'])}."
@@ -142,5 +156,6 @@ def summary_catalog_snapshot(connection):
             for row in indexes
         ],
         "sequence": [tuple(row) for row in sequence],
+        "external_dependency_count": external_dependency_count,
         "row_count": row_count,
     }

--- a/tests/practices/test_practice_migration_release.py
+++ b/tests/practices/test_practice_migration_release.py
@@ -1,0 +1,242 @@
+from datetime import date
+import os
+from pathlib import Path
+import subprocess
+import sys
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+
+from tests._db_guard import is_local_db
+from tests.practices.migration_test_support import (
+    create_exact_summary_orphan,
+    summary_catalog_snapshot,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE = ROOT / "scripts" / "release.sh"
+RELEASE_TIMEOUT_SECONDS = 30
+E36 = "e36bbec59bde"
+D8 = "d8b2c6f4a901"
+EXPECTED_C4_COLUMNS = {
+    ("practice_activities", "default_plan_reactions"),
+    ("practice_types", "default_plan_reactions"),
+    ("practices", "plan_reactions"),
+    ("practices", "slack_session_emoji"),
+}
+
+
+@pytest.fixture(scope="module")
+def engine():
+    database_url = os.environ["DATABASE_URL"]
+    assert is_local_db(database_url), "release tests require local PostgreSQL"
+    local_engine = create_engine(database_url)
+    yield local_engine
+    local_engine.dispose()
+
+
+@pytest.fixture
+def release_schema(engine):
+    schema = f"practice_release_{uuid4().hex}"
+    with engine.begin() as connection:
+        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+    try:
+        yield schema
+    finally:
+        with engine.begin() as connection:
+            connection.exec_driver_sql(f'DROP SCHEMA "{schema}" CASCADE')
+
+
+def _use_schema(connection, schema: str) -> None:
+    connection.exec_driver_sql(f'SET search_path TO "{schema}"')
+
+
+def _create_e36_baseline(connection, *, conflicting: bool) -> None:
+    connection.exec_driver_sql("""
+        CREATE TABLE alembic_version (
+            version_num VARCHAR(32) NOT NULL,
+            CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
+        )
+    """)
+    connection.exec_driver_sql(
+        "INSERT INTO alembic_version VALUES ('e36bbec59bde')"
+    )
+    connection.exec_driver_sql(
+        "CREATE TABLE practice_activities (id INTEGER PRIMARY KEY)"
+    )
+    connection.exec_driver_sql("""
+        CREATE TABLE practice_types (
+            id INTEGER PRIMARY KEY,
+            has_intervals BOOLEAN NOT NULL
+        )
+    """)
+    connection.exec_driver_sql("""
+        CREATE TABLE practices (
+            id INTEGER PRIMARY KEY,
+            date TIMESTAMP NOT NULL,
+            slack_coach_summary_ts VARCHAR(50),
+            slack_weekly_summary_ts VARCHAR(50)
+        )
+    """)
+    connection.exec_driver_sql("""
+        CREATE TABLE practice_types_junction (
+            practice_id INTEGER NOT NULL,
+            type_id INTEGER NOT NULL
+        )
+    """)
+    connection.exec_driver_sql(
+        "INSERT INTO practice_activities VALUES (1)"
+    )
+    connection.exec_driver_sql(
+        "INSERT INTO practice_types VALUES (10, TRUE), (20, FALSE)"
+    )
+    second_public = "public-2" if conflicting else "public-1"
+    connection.execute(text("""
+        INSERT INTO practices (
+            id, date, slack_coach_summary_ts, slack_weekly_summary_ts
+        ) VALUES
+            (1, '2026-07-13 18:00', 'coach-1', 'public-1'),
+            (2, '2026-07-15 18:00', 'coach-1', :second_public)
+    """), {"second_public": second_public})
+    connection.exec_driver_sql(
+        "INSERT INTO practice_types_junction VALUES (1, 10), (2, 20)"
+    )
+    create_exact_summary_orphan(connection)
+
+
+def _schema_database_url(schema: str) -> str:
+    url = make_url(os.environ["DATABASE_URL"])
+    scoped = url.update_query_dict({
+        "options": f"-csearch_path={schema}",
+    })
+    return scoped.render_as_string(hide_password=False)
+
+
+def _run_release(schema: str) -> subprocess.CompletedProcess[str]:
+    environment = os.environ.copy()
+    environment.update({
+        "PATH": (
+            f"{Path(sys.executable).parent}{os.pathsep}"
+            f"{environment['PATH']}"
+        ),
+        "DATABASE_URL": _schema_database_url(schema),
+        "FLASK_APP": "app:create_app",
+        "FLASK_ENV": "testing",
+        "FLASK_SECRET_KEY": "release-lifecycle-secret",
+        "STRIPE_SECRET_KEY": "sk_test_release_lifecycle",
+        "TCSC_MIGRATION_ONLY": "0",
+        "SLACK_BOT_TOKEN": "must-be-cleared",
+        "SLACK_APP_TOKEN": "must-be-cleared",
+        "SLACK_SIGNING_SECRET": "must-be-cleared",
+        "SLACK_USER_TOKEN": "",
+        "SLACK_WEBHOOK_URL": "",
+        "SLACK_ADMIN_TOKEN": "",
+        "SLACK_YOUR_COOKIE": "",
+        "SLACK_YOUR_X_ID": "",
+        "RENDER": "",
+    })
+    return subprocess.run(
+        ["bash", str(RELEASE)],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=RELEASE_TIMEOUT_SECONDS,
+    )
+
+
+def _revision(connection) -> str:
+    return connection.exec_driver_sql(
+        "SELECT version_num FROM alembic_version"
+    ).scalar_one()
+
+
+def _c4_columns(connection) -> set[tuple[str, str]]:
+    rows = connection.execute(text("""
+        SELECT table_name, column_name
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND (table_name, column_name) IN (
+            ('practice_activities', 'default_plan_reactions'),
+            ('practice_types', 'default_plan_reactions'),
+            ('practices', 'plan_reactions'),
+            ('practices', 'slack_session_emoji')
+          )
+    """)).all()
+    return {tuple(row) for row in rows}
+
+
+def test_release_lifecycle_upgrades_e36_orphan_to_d8_without_consumers(
+    engine, release_schema,
+):
+    with engine.begin() as connection:
+        _use_schema(connection, release_schema)
+        _create_e36_baseline(connection, conflicting=False)
+        baseline = summary_catalog_snapshot(connection)
+        assert _revision(connection) == E36
+        assert _c4_columns(connection) == set()
+        assert baseline["row_count"] == 0
+        baseline_defaults = {row[1]: row[6] for row in baseline["columns"]}
+        assert baseline_defaults["created_at"] is None
+        assert baseline_defaults["updated_at"] is None
+
+    result = _run_release(release_schema)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    output = result.stdout + result.stderr
+    assert "Running upgrade e36bbec59bde -> c4f1a8e2d9b7" in output
+    assert "Running upgrade c4f1a8e2d9b7 -> d8b2c6f4a901" in output
+    assert "=== Release tasks completed ===" in output
+    assert "APScheduler started successfully" not in output
+    assert "Slack Bolt enabled" not in output
+    assert "Socket Mode" not in output
+    with engine.connect() as connection:
+        _use_schema(connection, release_schema)
+        assert _revision(connection) == D8
+        assert _c4_columns(connection) == EXPECTED_C4_COLUMNS
+        after = summary_catalog_snapshot(connection)
+        defaults = {row[1]: row[6] for row in after["columns"]}
+        assert defaults["created_at"] == "now()"
+        assert defaults["updated_at"] == "now()"
+        assert connection.exec_driver_sql("""
+            SELECT week_start, surface, channel_id, message_ts
+            FROM practice_summary_posts
+            ORDER BY surface
+        """).all() == [
+            (date(2026, 7, 13), "coach_summary", None, "coach-1"),
+            (date(2026, 7, 13), "weekly_summary", None, "public-1"),
+        ]
+
+
+def test_release_lifecycle_conflict_rolls_back_c4_and_restores_orphan(
+    engine, release_schema,
+):
+    with engine.begin() as connection:
+        _use_schema(connection, release_schema)
+        _create_e36_baseline(connection, conflicting=True)
+        baseline = summary_catalog_snapshot(connection)
+        assert _revision(connection) == E36
+        assert _c4_columns(connection) == set()
+
+    result = _run_release(release_schema)
+
+    assert result.returncode != 0
+    assert "conflicting legacy practice summary timestamps" in (
+        result.stdout + result.stderr
+    )
+    with engine.connect() as connection:
+        _use_schema(connection, release_schema)
+        assert _revision(connection) == E36
+        assert _c4_columns(connection) == set()
+        restored = summary_catalog_snapshot(connection)
+        assert restored == baseline
+        defaults = {
+            row[1]: row[6]
+            for row in restored["columns"]
+        }
+        assert defaults["created_at"] is None
+        assert defaults["updated_at"] is None

--- a/tests/practices/test_practice_summary_post_migration.py
+++ b/tests/practices/test_practice_summary_post_migration.py
@@ -315,6 +315,7 @@ def _assert_upgrade_refused_without_mutation(
             "index mismatch",
             "external dependency mismatch",
             "attached behavior mismatch",
+            "publication membership mismatch",
             "table contains rows",
         )
     }
@@ -529,6 +530,35 @@ def test_upgrade_refuses_empty_orphan_with_policy_without_mutation(
             connection,
             monkeypatch,
             expected_invariant="attached behavior mismatch",
+        )
+
+
+def test_upgrade_refuses_empty_orphan_with_publication_membership_without_mutation(
+    engine,
+    monkeypatch,
+):
+    with migration_schema(engine, "summary_publication") as (
+        connection,
+        schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        quote = connection.dialect.identifier_preparer.quote
+        qualified = (
+            f"{quote(schema)}.{quote(revision.SUMMARY_TABLE)}"
+        )
+        connection.exec_driver_sql(f"""
+            CREATE PUBLICATION unexpected_summary_publication
+            FOR TABLE {qualified}
+        """)
+        assert summary_catalog_snapshot(connection)[
+            "publication_membership_count"
+        ] == 1
+
+        _assert_upgrade_refused_without_mutation(
+            connection,
+            monkeypatch,
+            expected_invariant="publication membership mismatch",
         )
 
 

--- a/tests/practices/test_practice_summary_post_migration.py
+++ b/tests/practices/test_practice_summary_post_migration.py
@@ -1,31 +1,78 @@
+from contextlib import contextmanager
 from datetime import date
+import os
+from unittest.mock import Mock
 from uuid import uuid4
 
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 import pytest
-from sqlalchemy import inspect
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.exc import DBAPIError
 
-from app import create_app
-from app.models import db
-from migrations.versions import d8b2c6f4a901_add_practice_summary_posts as revision
+from migrations.versions import (
+    d8b2c6f4a901_add_practice_summary_posts as revision,
+)
+from tests._db_guard import is_local_db
+from tests.practices.migration_test_support import (
+    create_exact_summary_orphan,
+    summary_catalog_snapshot,
+)
 
 
-@pytest.fixture
-def app():
-    application = create_app()
-    application.config.update(TESTING=True, SECRET_KEY="test-secret-key")
-    return application
+@pytest.fixture(scope="module")
+def engine():
+    database_url = os.environ["DATABASE_URL"]
+    assert is_local_db(database_url), "migration tests require local PostgreSQL"
+    local_engine = create_engine(database_url)
+    yield local_engine
+    local_engine.dispose()
 
 
-@pytest.fixture
-def db_session(app):
-    with app.app_context():
-        yield db
+@contextmanager
+def migration_schema(engine, prefix="practice_summary"):
+    schema = f"{prefix}_{uuid4().hex}"
+    connection = engine.connect()
+    transaction = connection.begin()
+    try:
+        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+        connection.exec_driver_sql(f'SET LOCAL search_path TO "{schema}"')
+        yield connection, schema
+    finally:
+        transaction.rollback()
+        connection.close()
 
 
-def _create_legacy_practices_table(connection):
+@contextmanager
+def committed_orphan_migration_schema(engine, prefix="summary_lock"):
+    schema = f"{prefix}_{uuid4().hex}"
+    with engine.begin() as setup_connection:
+        setup_connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
+        setup_connection.exec_driver_sql(
+            f'SET LOCAL search_path TO "{schema}"'
+        )
+        create_exact_summary_orphan(setup_connection)
+
+    connection = engine.connect()
+    transaction = connection.begin()
+    try:
+        connection.exec_driver_sql(f'SET LOCAL search_path TO "{schema}"')
+        yield connection, schema
+    finally:
+        transaction.rollback()
+        connection.close()
+        with engine.begin() as cleanup_connection:
+            cleanup_connection.exec_driver_sql(
+                f'DROP SCHEMA "{schema}" CASCADE'
+            )
+
+
+def configure_revision(connection, monkeypatch):
+    context = MigrationContext.configure(connection)
+    monkeypatch.setattr(revision, "op", Operations(context))
+
+
+def create_legacy_practices_table(connection):
     connection.exec_driver_sql("""
         CREATE TABLE practices (
             id INTEGER PRIMARY KEY,
@@ -36,17 +83,22 @@ def _create_legacy_practices_table(connection):
     """)
 
 
+def _access_exclusive_locks(connection, relation_oid):
+    return connection.execute(text("""
+        SELECT mode, granted
+        FROM pg_locks
+        WHERE pid = pg_backend_pid()
+          AND relation = :oid
+          AND mode = 'AccessExclusiveLock'
+    """), {"oid": relation_oid}).all()
+
+
 def test_upgrade_backfills_one_identity_per_linked_week_and_surface_and_downgrades(
-    db_session,
+    engine,
     monkeypatch,
 ):
-    schema = f"practice_summary_{uuid4().hex}"
-    connection = db_session.engine.connect()
-    transaction = connection.begin()
-    try:
-        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
-        connection.exec_driver_sql(f'SET LOCAL search_path TO "{schema}"')
-        _create_legacy_practices_table(connection)
+    with migration_schema(engine) as (connection, schema):
+        create_legacy_practices_table(connection)
         connection.exec_driver_sql("""
             INSERT INTO practices (
                 id,
@@ -60,8 +112,7 @@ def test_upgrade_backfills_one_identity_per_linked_week_and_surface_and_downgrad
                 (4, '2026-07-22 18:00', NULL, 'shared-ts')
         """)
 
-        context = MigrationContext.configure(connection)
-        monkeypatch.setattr(revision, "op", Operations(context))
+        configure_revision(connection, monkeypatch)
         revision.upgrade()
 
         rows = connection.exec_driver_sql("""
@@ -81,22 +132,16 @@ def test_upgrade_backfills_one_identity_per_linked_week_and_surface_and_downgrad
             "practice_summary_posts",
             schema=schema,
         )
-    finally:
-        transaction.rollback()
-        connection.close()
 
 
 def test_upgrade_rejects_conflicting_legacy_summary_timestamps(
-    db_session,
+    engine,
     monkeypatch,
 ):
-    schema = f"practice_summary_conflict_{uuid4().hex}"
-    connection = db_session.engine.connect()
-    transaction = connection.begin()
-    try:
-        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
-        connection.exec_driver_sql(f'SET LOCAL search_path TO "{schema}"')
-        _create_legacy_practices_table(connection)
+    with migration_schema(engine, "practice_summary_conflict") as (
+        connection, _schema,
+    ):
+        create_legacy_practices_table(connection)
         connection.exec_driver_sql("""
             INSERT INTO practices (
                 id,
@@ -107,29 +152,22 @@ def test_upgrade_rejects_conflicting_legacy_summary_timestamps(
                 (2, '2026-07-15 18:00', 'public-2')
         """)
 
-        context = MigrationContext.configure(connection)
-        monkeypatch.setattr(revision, "op", Operations(context))
+        configure_revision(connection, monkeypatch)
         with pytest.raises(
             DBAPIError,
             match="conflicting legacy practice summary timestamps",
         ):
             revision.upgrade()
-    finally:
-        transaction.rollback()
-        connection.close()
 
 
 def test_upgrade_rejects_one_summary_timestamp_mapped_to_multiple_weeks(
-    db_session,
+    engine,
     monkeypatch,
 ):
-    schema = f"practice_summary_cross_week_conflict_{uuid4().hex}"
-    connection = db_session.engine.connect()
-    transaction = connection.begin()
-    try:
-        connection.exec_driver_sql(f'CREATE SCHEMA "{schema}"')
-        connection.exec_driver_sql(f'SET LOCAL search_path TO "{schema}"')
-        _create_legacy_practices_table(connection)
+    with migration_schema(engine, "practice_summary_cross_week_conflict") as (
+        connection, _schema,
+    ):
+        create_legacy_practices_table(connection)
         connection.exec_driver_sql("""
             INSERT INTO practices (
                 id,
@@ -140,13 +178,336 @@ def test_upgrade_rejects_one_summary_timestamp_mapped_to_multiple_weeks(
                 (2, '2026-07-20 18:00', 'public-source-week')
         """)
 
-        context = MigrationContext.configure(connection)
-        monkeypatch.setattr(revision, "op", Operations(context))
+        configure_revision(connection, monkeypatch)
         with pytest.raises(
             DBAPIError,
             match="conflicting legacy practice summary timestamps",
         ):
             revision.upgrade()
+
+
+def test_upgrade_without_existing_summary_table_uses_normal_path(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_normal") as (connection, schema):
+        create_legacy_practices_table(connection)
+        configure_revision(connection, monkeypatch)
+
+        revision.upgrade()
+
+        assert inspect(connection).has_table(
+            "practice_summary_posts", schema=schema
+        )
+        defaults = {
+            row[0]: row[1]
+            for row in connection.execute(text("""
+                SELECT column_name, column_default
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'practice_summary_posts'
+                  AND column_name IN ('created_at', 'updated_at')
+            """))
+        }
+        assert defaults == {"created_at": "now()", "updated_at": "now()"}
+
+
+def test_existing_orphan_lock_is_access_exclusive(engine):
+    with committed_orphan_migration_schema(engine) as (connection, _schema):
+        oid = revision._visible_summary_table_oid(connection)
+        assert _access_exclusive_locks(connection, oid) == []
+
+        locked_oid = revision._lock_existing_summary_table(connection, oid)
+
+        assert locked_oid == oid
+        assert _access_exclusive_locks(connection, oid) == [
+            ("AccessExclusiveLock", True),
+        ]
+
+
+def test_upgrade_adopts_exact_empty_orm_orphan_and_backfills(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_adopt") as (connection, schema):
+        create_legacy_practices_table(connection)
+        connection.exec_driver_sql("""
+            INSERT INTO practices (
+                id, date, slack_coach_summary_ts, slack_weekly_summary_ts
+            ) VALUES
+                (1, '2026-07-13 18:00', 'coach-1', 'public-1'),
+                (2, '2026-07-15 18:00', 'coach-1', 'public-1')
+        """)
+        create_exact_summary_orphan(connection)
+        before = summary_catalog_snapshot(connection)
+        old_oid = revision._visible_summary_table_oid(connection)
+        assert before["row_count"] == 0
+        assert dict(
+            (row[1], row[6]) for row in before["columns"]
+        )["created_at"] is None
+        configure_revision(connection, monkeypatch)
+
+        expected_savepoint = connection.begin_nested()
+        try:
+            connection.exec_driver_sql(
+                f'DROP TABLE "{schema}".practice_summary_posts'
+            )
+            revision.upgrade()
+            expected = summary_catalog_snapshot(connection)
+        finally:
+            expected_savepoint.rollback()
+
+        assert summary_catalog_snapshot(connection) == before
+        drop_table = Mock(wraps=revision.op.drop_table)
+        monkeypatch.setattr(revision.op, "drop_table", drop_table)
+        revision.upgrade()
+
+        after = summary_catalog_snapshot(connection)
+        assert revision._visible_summary_table_oid(connection) != old_oid
+        assert after == expected
+        drop_table.assert_called_once_with(
+            revision.SUMMARY_TABLE,
+            schema=schema,
+        )
+        rows = connection.exec_driver_sql("""
+            SELECT week_start, surface, channel_id, message_ts
+            FROM practice_summary_posts
+            ORDER BY surface
+        """).all()
+        assert rows == [
+            (date(2026, 7, 13), "coach_summary", None, "coach-1"),
+            (date(2026, 7, 13), "weekly_summary", None, "public-1"),
+        ]
+
+
+def _assert_upgrade_refused_without_mutation(connection, monkeypatch):
+    before = summary_catalog_snapshot(connection)
+    configure_revision(connection, monkeypatch)
+    drop_table = Mock(wraps=revision.op.drop_table)
+    monkeypatch.setattr(revision.op, "drop_table", drop_table)
+
+    savepoint = connection.begin_nested()
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="practice_summary_posts orphan recovery refused",
+        ) as refusal:
+            revision.upgrade()
     finally:
-        transaction.rollback()
-        connection.close()
+        savepoint.rollback()
+
+    assert str(refusal.value) in {
+        "practice_summary_posts orphan recovery refused: " + invariant
+        for invariant in (
+            "relation changed before lock",
+            "relation could not be locked",
+            "relation changed while acquiring lock",
+            "locked relation is no longer visible",
+            "relation metadata mismatch",
+            "column shape mismatch",
+            "id serial default mismatch",
+            "non-id column default mismatch",
+            "owned serial sequence mismatch",
+            "constraint mismatch",
+            "index mismatch",
+            "table contains rows",
+        )
+    }
+    drop_table.assert_not_called()
+    assert summary_catalog_snapshot(connection) == before
+
+
+def test_upgrade_refuses_nonempty_orm_orphan_without_mutation(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_nonempty") as (connection, _schema):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            INSERT INTO practice_summary_posts (
+                id, week_start, surface, message_ts, created_at, updated_at
+            ) VALUES (
+                1, '2026-07-13', 'weekly_summary', 'existing', now(), now()
+            )
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+def test_upgrade_refuses_noncanonical_nextval_default_without_mutation(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_default") as (connection, _schema):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE FUNCTION nextval(regclass, integer)
+            RETURNS bigint
+            LANGUAGE SQL VOLATILE
+            AS 'SELECT pg_catalog.nextval($1) + $2'
+        """)
+        connection.exec_driver_sql("""
+            ALTER TABLE practice_summary_posts ALTER COLUMN id
+            SET DEFAULT nextval(
+                'practice_summary_posts_id_seq'::regclass,
+                0
+            )
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+def test_upgrade_refuses_partition_child_without_mutation(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_partition") as (
+        connection, _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE TABLE summary_partition_parent (
+                id INTEGER NOT NULL,
+                week_start DATE NOT NULL,
+                surface VARCHAR(32) NOT NULL,
+                channel_id VARCHAR(50),
+                message_ts VARCHAR(50) NOT NULL,
+                created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+                updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL
+            ) PARTITION BY RANGE (week_start)
+        """)
+        connection.exec_driver_sql("""
+            ALTER TABLE summary_partition_parent
+            ATTACH PARTITION practice_summary_posts
+            FOR VALUES FROM (MINVALUE) TO (MAXVALUE)
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+def test_upgrade_checks_rows_on_locked_schema_despite_temp_shadow(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_shadow") as (connection, _schema):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            INSERT INTO practice_summary_posts (
+                id, week_start, surface, message_ts, created_at, updated_at
+            ) VALUES (
+                1, '2026-07-13', 'weekly_summary',
+                'sensitive-shadow-ts', now(), now()
+            )
+        """)
+        connection.exec_driver_sql("""
+            CREATE TEMP TABLE practice_summary_posts (id INTEGER)
+            ON COMMIT DROP
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+@pytest.mark.parametrize(
+    "malformation",
+    [
+        pytest.param(
+            "ALTER TABLE practice_summary_posts DROP CONSTRAINT "
+            "ck_practice_summary_post_surface",
+            id="missing-check",
+        ),
+        pytest.param(
+            "CREATE INDEX unexpected_summary_message_index "
+            "ON practice_summary_posts (message_ts)",
+            id="unexpected-index",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts SET UNLOGGED",
+            id="non-permanent-relation",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts ENABLE ROW LEVEL SECURITY",
+            id="row-security",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts "
+            "ALTER COLUMN channel_id TYPE VARCHAR(51)",
+            id="column-shape",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts ALTER COLUMN id DROP DEFAULT",
+            id="serial-default",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts DROP CONSTRAINT "
+            "practice_summary_posts_pkey",
+            id="missing-primary-key",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts DROP CONSTRAINT "
+            "uq_practice_summary_post_week_surface",
+            id="missing-unique",
+        ),
+        pytest.param(
+            "ALTER TABLE practice_summary_posts ADD CONSTRAINT "
+            "unexpected_summary_fk FOREIGN KEY (id) "
+            "REFERENCES practice_summary_posts(id)",
+            id="unexpected-foreign-key",
+        ),
+        pytest.param(
+            "ALTER SEQUENCE practice_summary_posts_id_seq "
+            "RENAME TO unexpected_summary_id_seq",
+            id="sequence-identity",
+        ),
+        pytest.param(
+            "ALTER SEQUENCE practice_summary_posts_id_seq OWNED BY NONE",
+            id="sequence-ownership",
+        ),
+    ],
+)
+def test_upgrade_refuses_malformed_orm_orphan_without_mutation(
+    engine, monkeypatch, malformation,
+):
+    with migration_schema(engine, "summary_malformed") as (
+        connection, _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql(malformation)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+def test_upgrade_refuses_non_table_relation_without_mutation(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_view") as (connection, _schema):
+        create_legacy_practices_table(connection)
+        connection.exec_driver_sql("""
+            CREATE VIEW practice_summary_posts AS
+            SELECT
+                1::integer AS id,
+                DATE '2026-07-13' AS week_start,
+                'coach_summary'::varchar(32) AS surface,
+                NULL::varchar(50) AS channel_id,
+                'view-message'::varchar(50) AS message_ts,
+                now()::timestamp AS created_at,
+                now()::timestamp AS updated_at
+            WHERE FALSE
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+def test_upgrade_refuses_canonical_preexisting_table_without_mutation(
+    engine, monkeypatch,
+):
+    with migration_schema(engine, "summary_canonical") as (
+        connection, _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            ALTER TABLE practice_summary_posts
+              ALTER COLUMN created_at SET DEFAULT now(),
+              ALTER COLUMN updated_at SET DEFAULT now()
+        """)
+
+        _assert_upgrade_refused_without_mutation(connection, monkeypatch)

--- a/tests/practices/test_practice_summary_post_migration.py
+++ b/tests/practices/test_practice_summary_post_migration.py
@@ -240,6 +240,7 @@ def test_upgrade_adopts_exact_empty_orm_orphan_and_backfills(
         before = summary_catalog_snapshot(connection)
         old_oid = revision._visible_summary_table_oid(connection)
         assert before["row_count"] == 0
+        assert before["external_dependency_count"] == 0
         assert dict(
             (row[1], row[6]) for row in before["columns"]
         )["created_at"] is None
@@ -278,7 +279,11 @@ def test_upgrade_adopts_exact_empty_orm_orphan_and_backfills(
         ]
 
 
-def _assert_upgrade_refused_without_mutation(connection, monkeypatch):
+def _assert_upgrade_refused_without_mutation(
+    connection,
+    monkeypatch,
+    expected_invariant=None,
+):
     before = summary_catalog_snapshot(connection)
     configure_revision(connection, monkeypatch)
     drop_table = Mock(wraps=revision.op.drop_table)
@@ -294,7 +299,7 @@ def _assert_upgrade_refused_without_mutation(connection, monkeypatch):
     finally:
         savepoint.rollback()
 
-    assert str(refusal.value) in {
+    allowed_messages = {
         "practice_summary_posts orphan recovery refused: " + invariant
         for invariant in (
             "relation changed before lock",
@@ -308,9 +313,17 @@ def _assert_upgrade_refused_without_mutation(connection, monkeypatch):
             "owned serial sequence mismatch",
             "constraint mismatch",
             "index mismatch",
+            "external dependency mismatch",
             "table contains rows",
         )
     }
+    if expected_invariant is None:
+        assert str(refusal.value) in allowed_messages
+    else:
+        assert str(refusal.value) == (
+            "practice_summary_posts orphan recovery refused: "
+            + expected_invariant
+        )
     drop_table.assert_not_called()
     assert summary_catalog_snapshot(connection) == before
 
@@ -381,6 +394,83 @@ def test_upgrade_refuses_partition_child_without_mutation(
         """)
 
         _assert_upgrade_refused_without_mutation(connection, monkeypatch)
+
+
+def test_upgrade_refuses_empty_orphan_with_inheritance_child_without_mutation(
+    engine,
+    monkeypatch,
+):
+    with migration_schema(engine, "summary_inheritance_child") as (
+        connection,
+        _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE TABLE dependent_summary_child ()
+            INHERITS (practice_summary_posts)
+        """)
+        assert summary_catalog_snapshot(connection)[
+            "external_dependency_count"
+        ] > 0
+
+        _assert_upgrade_refused_without_mutation(
+            connection,
+            monkeypatch,
+            expected_invariant="external dependency mismatch",
+        )
+
+
+def test_upgrade_refuses_empty_orphan_with_dependent_view_without_mutation(
+    engine,
+    monkeypatch,
+):
+    with migration_schema(engine, "summary_dependent_view") as (
+        connection,
+        _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE VIEW dependent_summary_view AS
+            SELECT id, week_start
+            FROM practice_summary_posts
+        """)
+        assert summary_catalog_snapshot(connection)[
+            "external_dependency_count"
+        ] > 0
+
+        _assert_upgrade_refused_without_mutation(
+            connection,
+            monkeypatch,
+            expected_invariant="external dependency mismatch",
+        )
+
+
+def test_upgrade_refuses_empty_orphan_with_inbound_foreign_key_without_mutation(
+    engine,
+    monkeypatch,
+):
+    with migration_schema(engine, "summary_inbound_fk") as (
+        connection,
+        _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE TABLE dependent_summary_fk (
+                summary_id INTEGER REFERENCES practice_summary_posts(id)
+            )
+        """)
+        assert summary_catalog_snapshot(connection)[
+            "external_dependency_count"
+        ] > 0
+
+        _assert_upgrade_refused_without_mutation(
+            connection,
+            monkeypatch,
+            expected_invariant="external dependency mismatch",
+        )
 
 
 def test_upgrade_checks_rows_on_locked_schema_despite_temp_shadow(

--- a/tests/practices/test_practice_summary_post_migration.py
+++ b/tests/practices/test_practice_summary_post_migration.py
@@ -314,6 +314,7 @@ def _assert_upgrade_refused_without_mutation(
             "constraint mismatch",
             "index mismatch",
             "external dependency mismatch",
+            "attached behavior mismatch",
             "table contains rows",
         )
     }
@@ -470,6 +471,64 @@ def test_upgrade_refuses_empty_orphan_with_inbound_foreign_key_without_mutation(
             connection,
             monkeypatch,
             expected_invariant="external dependency mismatch",
+        )
+
+
+def test_upgrade_refuses_empty_orphan_with_user_trigger_without_mutation(
+    engine,
+    monkeypatch,
+):
+    with migration_schema(engine, "summary_user_trigger") as (
+        connection,
+        _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE FUNCTION keep_summary_row()
+            RETURNS trigger
+            LANGUAGE plpgsql
+            AS $$ BEGIN RETURN NEW; END $$
+        """)
+        connection.exec_driver_sql("""
+            CREATE TRIGGER unexpected_summary_trigger
+            BEFORE INSERT ON practice_summary_posts
+            FOR EACH ROW EXECUTE FUNCTION keep_summary_row()
+        """)
+        assert summary_catalog_snapshot(connection)[
+            "attached_behavior"
+        ] == (1, 0)
+
+        _assert_upgrade_refused_without_mutation(
+            connection,
+            monkeypatch,
+            expected_invariant="attached behavior mismatch",
+        )
+
+
+def test_upgrade_refuses_empty_orphan_with_policy_without_mutation(
+    engine,
+    monkeypatch,
+):
+    with migration_schema(engine, "summary_policy") as (
+        connection,
+        _schema,
+    ):
+        create_legacy_practices_table(connection)
+        create_exact_summary_orphan(connection)
+        connection.exec_driver_sql("""
+            CREATE POLICY unexpected_summary_policy
+            ON practice_summary_posts
+            USING (true)
+        """)
+        assert summary_catalog_snapshot(connection)[
+            "attached_behavior"
+        ] == (0, 1)
+
+        _assert_upgrade_refused_without_mutation(
+            connection,
+            monkeypatch,
+            expected_invariant="attached behavior mismatch",
         )
 
 

--- a/tests/scripts/test_release.py
+++ b/tests/scripts/test_release.py
@@ -1,0 +1,117 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE = ROOT / "scripts" / "release.sh"
+
+
+def test_release_runs_upgrade_with_migration_only_and_blank_slack_environment(
+    tmp_path,
+):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_flask = fake_bin / "flask"
+    fake_flask.write_text(
+        """#!/bin/sh
+{
+  printf 'argv=%s\\n' "$*"
+  printf 'migration_only=%s\\n' "${TCSC_MIGRATION_ONLY-unset}"
+  printf 'bot=%s\\n' "${SLACK_BOT_TOKEN-unset}"
+  printf 'app=%s\\n' "${SLACK_APP_TOKEN-unset}"
+  printf 'signing=%s\\n' "${SLACK_SIGNING_SECRET-unset}"
+} >> "$TCSC_RELEASE_CAPTURE"
+""",
+        encoding="utf-8",
+    )
+    fake_flask.chmod(0o755)
+    capture = tmp_path / "release-environment.txt"
+    environment = os.environ.copy()
+    environment.update({
+        "PATH": f"{fake_bin}{os.pathsep}{environment['PATH']}",
+        "TCSC_RELEASE_CAPTURE": str(capture),
+        "TCSC_MIGRATION_ONLY": "0",
+        "SLACK_BOT_TOKEN": "must-be-cleared",
+        "SLACK_APP_TOKEN": "must-be-cleared",
+        "SLACK_SIGNING_SECRET": "must-be-cleared",
+    })
+
+    result = subprocess.run(
+        ["bash", str(RELEASE)],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert capture.read_text(encoding="utf-8").splitlines() == [
+        "argv=db upgrade",
+        "migration_only=1",
+        "bot=",
+        "app=",
+        "signing=",
+    ]
+
+
+def test_migration_only_process_starts_no_background_consumers():
+    probe = r"""
+import json
+from unittest.mock import Mock
+
+import app as app_module
+import app.scheduler as scheduler_module
+import app.slack.bolt_app as bolt_module
+
+app_module.load_stripe_config = lambda: None
+create_all = Mock(side_effect=AssertionError("schema mutation"))
+init_scheduler = Mock(side_effect=AssertionError("background startup"))
+app_module.db.create_all = create_all
+app_module.init_scheduler = init_scheduler
+application = app_module.create_app()
+print(json.dumps({
+    "create_all_calls": create_all.call_count,
+    "scheduler_calls": init_scheduler.call_count,
+    "migrate_registered": "migrate" in application.extensions,
+    "bolt_enabled": bolt_module.is_bolt_enabled(),
+    "socket_available": bolt_module.is_socket_mode_available(),
+    "socket_running": bolt_module.is_socket_mode_running(),
+    "scheduler_running": scheduler_module.scheduler.running,
+}))
+"""
+    environment = os.environ.copy()
+    environment.update({
+        "DATABASE_URL": (
+            "postgresql://tcsc:tcsc@localhost:5432/tcsc_trips"
+        ),
+        "FLASK_SECRET_KEY": "release-process-test-secret",
+        "TCSC_MIGRATION_ONLY": "1",
+        "SLACK_BOT_TOKEN": "",
+        "SLACK_APP_TOKEN": "",
+        "SLACK_SIGNING_SECRET": "",
+    })
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=ROOT,
+        env=environment,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    state = json.loads(result.stdout.strip().splitlines()[-1])
+    assert state == {
+        "create_all_calls": 0,
+        "scheduler_calls": 0,
+        "migrate_registered": True,
+        "bolt_enabled": False,
+        "socket_available": False,
+        "socket_running": False,
+        "scheduler_running": False,
+    }

--- a/tests/test_app_startup.py
+++ b/tests/test_app_startup.py
@@ -1,0 +1,55 @@
+from unittest.mock import Mock
+
+import app as app_module
+
+
+def _prepare_factory(monkeypatch):
+    monkeypatch.setattr(app_module, "load_stripe_config", lambda: None)
+    monkeypatch.setenv("FLASK_SECRET_KEY", "startup-test-secret")
+    monkeypatch.setenv(
+        "DATABASE_URL",
+        "postgresql://tcsc:tcsc@localhost:5432/tcsc_trips",
+    )
+
+
+def test_create_app_never_calls_create_all(monkeypatch):
+    _prepare_factory(monkeypatch)
+    monkeypatch.delenv("TCSC_MIGRATION_ONLY", raising=False)
+    create_all = Mock(side_effect=AssertionError("schema mutation"))
+    scheduler = Mock(return_value=False)
+    monkeypatch.setattr(app_module.db, "create_all", create_all)
+    monkeypatch.setattr(app_module, "init_scheduler", scheduler)
+
+    application = app_module.create_app()
+
+    create_all.assert_not_called()
+    scheduler.assert_called_once_with(application)
+
+
+def test_create_app_starts_scheduler_for_non_migration_only_value(monkeypatch):
+    _prepare_factory(monkeypatch)
+    monkeypatch.setenv("TCSC_MIGRATION_ONLY", "0")
+    create_all = Mock(side_effect=AssertionError("schema mutation"))
+    scheduler = Mock(return_value=False)
+    monkeypatch.setattr(app_module.db, "create_all", create_all)
+    monkeypatch.setattr(app_module, "init_scheduler", scheduler)
+
+    application = app_module.create_app()
+
+    create_all.assert_not_called()
+    scheduler.assert_called_once_with(application)
+
+
+def test_create_app_skips_scheduler_in_migration_only_mode(monkeypatch):
+    _prepare_factory(monkeypatch)
+    monkeypatch.setenv("TCSC_MIGRATION_ONLY", "1")
+    create_all = Mock(side_effect=AssertionError("schema mutation"))
+    scheduler = Mock(return_value=False)
+    monkeypatch.setattr(app_module.db, "create_all", create_all)
+    monkeypatch.setattr(app_module, "init_scheduler", scheduler)
+
+    application = app_module.create_app()
+
+    assert "migrate" in application.extensions
+    create_all.assert_not_called()
+    scheduler.assert_not_called()


### PR DESCRIPTION
## Summary

- remove runtime schema creation and isolate Render pre-deploy from scheduler/Slack consumers
- transactionally replace only the exact empty ORM-created practice summary orphan
- fail closed on schema/default/constraint/index/row/dependency drift plus triggers, policies, and publication membership
- prove successful e36 → c4 → d8 release and complete rollback with real PostgreSQL lifecycle tests

## Verification

- 1,235 Python tests passed
- 51 practice-reaction UI tests passed
- release shell syntax and branch diff checks passed
- sole Alembic head: d8b2c6f4a901
- independent final review: Ready to merge
- fresh read-only production audit: e36bbec59bde, exact empty orphan accepted, zero c4 columns, zero trigger/policy/publication/rule metadata

## Rollout

Merging to main should trigger the Render tcsc-registration pre-deploy. Do not stamp or manually modify production DDL. Keep the practice-writer quiet window active until the deployed Preview succeeds.
