### PR TITLE
Fix mobile safe-area layout

### DIFF
--- a/site/src/components/CTAStrip.astro
+++ b/site/src/components/CTAStrip.astro
@@ -8,7 +8,7 @@ interface Props {
 const { heading, subhead, cta_label, cta_url } = Astro.props;
 ---
 <section class="bg-navy border-t-[3px] border-coral text-paper">
-  <div class="mx-auto max-w-7xl px-6 py-16 md:py-20 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+  <div class="safe-inline-6 mx-auto max-w-7xl px-6 py-16 md:py-20 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
     <div>
       <h2 class="font-display font-semibold text-3xl md:text-4xl text-mint leading-tight">{heading}</h2>
       {subhead && <p class="mt-2 text-paper/75 text-sm md:text-base max-w-xl text-balance">{subhead}</p>}

--- a/site/src/components/CoachEntry.astro
+++ b/site/src/components/CoachEntry.astro
@@ -53,7 +53,7 @@ const height = Math.round((width * 5) / 4);
 <article id={anchor} class="border-b border-ink/10 last:border-b-0 scroll-mt-24">
   {/* All photos sit left: a steady column instead of an alternator
       performing fake variety. */}
-  <div class="mx-auto max-w-6xl px-6 py-12 md:py-16 grid gap-8 md:gap-14 md:grid-cols-12 items-start">
+  <div class="safe-inline-6 mx-auto max-w-6xl px-6 py-12 md:py-16 grid gap-8 md:gap-14 md:grid-cols-12 items-start">
     <div class="md:col-span-5">
       <div class="relative aspect-[4/5] overflow-hidden">
         <Image

--- a/site/src/components/Footer.astro
+++ b/site/src/components/Footer.astro
@@ -24,7 +24,7 @@ const colB = [
 ];
 ---
 <footer class="bg-navy text-paper border-t border-mint/10">
-  <div class="mx-auto max-w-7xl px-6 py-14 grid gap-10 md:grid-cols-3">
+  <div class="footer-inner safe-inline-6 mx-auto max-w-7xl px-6 pt-14 pb-14 grid gap-10 md:grid-cols-3">
     <div>
       <div class="font-display font-bold uppercase text-[13px] tracking-[0.08em] text-mint">Twin Cities Ski Club</div>
       <p class="mt-3 text-sm text-paper/70 max-w-xs leading-relaxed">
@@ -32,18 +32,24 @@ const colB = [
       </p>
     </div>
     <nav aria-label="Footer" class="text-sm grid grid-cols-2 gap-x-6 content-start">
-      <div class="space-y-2">
-        {colA.map((l) => <a class="block hover:text-mint" href={l.href}>{l.label}</a>)}
+      <div class="md:space-y-2">
+        {colA.map((l) => <a class="flex min-h-11 items-center hover:text-mint md:min-h-0 md:block" href={l.href}>{l.label}</a>)}
       </div>
-      <div class="space-y-2">
-        {colB.map((l) => <a class="block hover:text-mint" href={l.href}>{l.label}</a>)}
+      <div class="md:space-y-2">
+        {colB.map((l) => <a class="flex min-h-11 items-center hover:text-mint md:min-h-0 md:block" href={l.href}>{l.label}</a>)}
       </div>
     </nav>
     <div class="text-sm space-y-2">
-      <a class="block hover:text-mint" href={'mailto:' + email}>{email}</a>
-      <a class="block hover:text-mint" href={ig}>Instagram</a>
+      <a class="flex min-h-11 items-center hover:text-mint md:min-h-0 md:block" href={'mailto:' + email}>{email}</a>
+      <a class="flex min-h-11 items-center hover:text-mint md:min-h-0 md:block" href={ig}>Instagram</a>
       <p class="text-paper/50 pt-3">All photos by club members.</p>
       <p class="text-paper/50">© {new Date().getFullYear()} Twin Cities Ski Club</p>
     </div>
   </div>
 </footer>
+
+<style>
+  .footer-inner {
+    padding-bottom: calc(3.5rem + env(safe-area-inset-bottom, 0px));
+  }
+</style>

--- a/site/src/components/HeroHome.astro
+++ b/site/src/components/HeroHome.astro
@@ -23,7 +23,7 @@ const props = Astro.props;
 // width itself as a candidate, so it never upscales (see imageWidths.ts).
 ---
 <section class="relative bg-navy overflow-hidden">
-  <div class="relative h-[74vh] min-h-[540px]">
+  <div class="hero-frame relative">
     {props.image && (
       <Picture
         src={props.image}
@@ -40,7 +40,7 @@ const props = Astro.props;
     {/* Functional scrim: heavy only at the text zone, light by 45% up so
         the photograph actually shows. */}
     <div class="absolute inset-0 bg-gradient-to-t from-navy/95 via-navy/50 via-45% to-transparent"></div>
-    <div class="relative h-full mx-auto max-w-7xl px-6 flex flex-col justify-end pb-14 md:pb-20 text-paper">
+    <div class="safe-inline-6 relative h-full mx-auto max-w-7xl px-6 flex flex-col justify-end pb-14 md:pb-20 text-paper">
       <h1 class="hero-headline font-display font-semibold text-4xl sm:text-5xl md:text-7xl leading-[1.02] text-mint max-w-5xl text-balance">{props.headline}</h1>
       {props.subline && (
         <p class="hero-headline mt-4 text-base md:text-lg text-paper/85 max-w-prose-narrow">{props.subline}</p>
@@ -58,6 +58,20 @@ const props = Astro.props;
 </section>
 
 <style>
+  /* svh is stable while mobile browser chrome expands and retracts. The
+     bounded minimum keeps the composition usable in short landscape views
+     without forcing the old 540px frame beyond the visible screen. */
+  .hero-frame {
+    height: 74vh;
+    min-height: min(540px, 100vh);
+  }
+  @supports (height: 100svh) {
+    .hero-frame {
+      height: 74svh;
+      min-height: min(540px, 100svh);
+    }
+  }
+
   /* The single orchestrated page-load: photo fades in, headline rises 8px
      just behind it. One entrance per load, then total stillness (no scroll
      animation anywhere on the site). Transform/opacity only; the global

--- a/site/src/components/HeroInner.astro
+++ b/site/src/components/HeroInner.astro
@@ -25,7 +25,7 @@ interface Props {
 const { headline, subhead, facts = [], photo, photoAlt, photoPosition } = Astro.props;
 ---
 <section class="bg-paper text-ink border-y border-ink/15">
-  <div class="mx-auto max-w-7xl px-6 py-10 md:py-14 grid gap-x-10 gap-y-6 md:grid-cols-12">
+  <div class="safe-inline-6 mx-auto max-w-7xl px-6 py-10 md:py-14 grid gap-x-10 gap-y-6 md:grid-cols-12">
     <div class:list={[facts.length > 0 ? 'md:col-span-7' : 'md:col-span-9']}>
       <h1 class="font-display font-semibold text-4xl md:text-6xl leading-[1.05] text-navy">{headline}</h1>
       {subhead && <p class="mt-4 text-lg md:text-xl text-slate max-w-prose">{subhead}</p>}

--- a/site/src/components/Lightbox.astro
+++ b/site/src/components/Lightbox.astro
@@ -10,7 +10,7 @@
 ---
 <div
   data-lightbox
-  class="fixed inset-0 z-50 hidden bg-ink/95 text-paper p-4 md:p-12 flex-col [--focus-ring-color:theme(colors.mint)]"
+  class="lightbox-shell fixed inset-0 z-50 hidden bg-ink/95 text-paper flex-col [--focus-ring-color:theme(colors.mint)]"
   role="dialog"
   aria-modal="true"
   aria-label="Photo viewer"
@@ -28,7 +28,29 @@
       caption-less photos still give screen readers navigation feedback. */}
   <div class="mt-4 max-w-3xl mx-auto text-center text-sm" data-lightbox-caption aria-live="polite"></div>
   <div class="flex justify-center gap-6 mt-6">
-    <button class="px-5 py-2 border border-paper/30 rounded" data-lightbox-prev aria-label="Previous photo">←</button>
-    <button class="px-5 py-2 border border-paper/30 rounded" data-lightbox-next aria-label="Next photo">→</button>
+    <button class="min-h-11 min-w-11 px-5 py-2 border border-paper/30 rounded" data-lightbox-prev aria-label="Previous photo">←</button>
+    <button class="min-h-11 min-w-11 px-5 py-2 border border-paper/30 rounded" data-lightbox-next aria-label="Next photo">→</button>
   </div>
 </div>
+
+<style>
+  .lightbox-shell {
+    --lightbox-gutter: 1rem;
+    --lightbox-safe-gap: 0.75rem;
+    box-sizing: border-box;
+    width: 100%;
+    height: 100vh;
+    height: 100dvh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-top: max(var(--lightbox-gutter), calc(env(safe-area-inset-top, 0px) + var(--lightbox-safe-gap)));
+    padding-right: max(var(--lightbox-gutter), calc(env(safe-area-inset-right, 0px) + var(--lightbox-safe-gap)));
+    padding-bottom: max(var(--lightbox-gutter), calc(env(safe-area-inset-bottom, 0px) + var(--lightbox-safe-gap)));
+    padding-left: max(var(--lightbox-gutter), calc(env(safe-area-inset-left, 0px) + var(--lightbox-safe-gap)));
+  }
+  @media (min-width: 48rem) {
+    .lightbox-shell {
+      --lightbox-gutter: 3rem;
+    }
+  }
+</style>

--- a/site/src/components/LiveConditions.astro
+++ b/site/src/components/LiveConditions.astro
@@ -32,11 +32,11 @@ const locations = [
   <span class="sr-only" aria-live="polite" data-announcer></span>
   {variant === 'prominent' ? (
     <>
-      <div class="mx-auto max-w-7xl px-6 pt-3 pb-2 flex flex-wrap items-baseline gap-x-4 gap-y-0.5">
+      <div class="safe-inline-6 mx-auto max-w-7xl px-6 pt-3 pb-2 flex flex-wrap items-baseline gap-x-4 gap-y-0.5">
         <span class="text-[11px] tracking-[0.18em] uppercase font-semibold text-mint/90 shrink-0">Trail report</span>
         <span class="text-[11px] text-coral ml-auto text-right min-w-0" data-updated>Loading conditions…</span>
       </div>
-      <div class="mx-auto max-w-7xl px-6 pb-4 grid grid-cols-2 md:grid-cols-5 gap-y-4">
+      <div class="safe-inline-6 mx-auto max-w-7xl px-6 pb-4 grid grid-cols-2 md:grid-cols-5 gap-y-4">
         {/* On a phone the full grid is overwhelming, so mobile leads with just
             the Theodore Wirth cell (the club's home venue); the other three
             venues and the fever cell are desktop-only. */}
@@ -87,7 +87,7 @@ const locations = [
       </div>
     </>
   ) : (
-    <div class="mx-auto max-w-7xl px-6 py-2 flex gap-x-4 gap-y-1 flex-wrap text-paper/70">
+    <div class="safe-inline-6 mx-auto max-w-7xl px-6 py-2 flex gap-x-4 gap-y-1 flex-wrap text-paper/70">
       {/* Mobile keeps just the Theodore Wirth line; the other venues and the
           fever line are desktop-only. */}
       {locations.map(({ id, name }) => (

--- a/site/src/components/MissionPanel.astro
+++ b/site/src/components/MissionPanel.astro
@@ -14,7 +14,7 @@ const facts: Array<{ value: string; label: string; big?: boolean }> = [
 ---
 <section class="bg-navy pt-14 md:pt-20">
   <div class="bg-paper text-ink">
-    <div class="mx-auto max-w-7xl px-6 py-14 md:py-20 grid gap-10 md:grid-cols-12">
+    <div class="safe-inline-6 mx-auto max-w-7xl px-6 py-14 md:py-20 grid gap-10 md:grid-cols-12">
       <p class="md:col-span-8 font-display text-2xl md:text-3xl leading-[1.25] text-navy">{body}</p>
       <ul class="md:col-span-3 md:col-start-10 self-center md:border-l md:border-ink/15 md:pl-7 space-y-5">
         {facts.map((f) => (

--- a/site/src/components/MobileNavPanel.astro
+++ b/site/src/components/MobileNavPanel.astro
@@ -10,7 +10,7 @@ const pathname = Astro.url.pathname;
   role="dialog"
   aria-modal="true"
   aria-label="Menu"
-  class="fixed inset-0 z-50 bg-navy text-paper p-8 hidden flex-col"
+  class="mobile-panel-shell fixed inset-0 z-50 bg-navy text-paper hidden flex-col"
   aria-hidden="true"
 >
   <button class="self-end p-2.5 -m-2.5" aria-label="Close menu" data-mobile-close>
@@ -21,20 +21,20 @@ const pathname = Astro.url.pathname;
 
   {/* "Mobile", not "Primary": the desktop header nav already owns that
       name and both landmarks coexist in the DOM. */}
-  <nav aria-label="Mobile" class="flex-1 flex flex-col justify-center gap-6 text-2xl">
+  <nav aria-label="Mobile" class="flex-1 min-h-fit flex flex-col justify-center gap-1 py-4 text-2xl">
     {links.map((l) => {
       const active = isActiveLink(l.href, pathname);
       return (
         <a
           href={l.href}
           aria-current={active ? 'page' : undefined}
-          class:list={['hover:text-mint', active && 'text-mint']}
+          class:list={['flex min-h-11 items-center hover:text-mint', active && 'text-mint']}
         >{l.label}</a>
       );
     })}
   </nav>
 
-  <div class="mt-auto">
+  <div class="shrink-0 pt-2">
     <slot name="cta" />
   </div>
 </div>
@@ -44,6 +44,17 @@ const pathname = Astro.url.pathname;
      list rises 8px. Transform/opacity only; the global reduced-motion rule
      collapses both. */
   [data-mobile-panel] {
+    box-sizing: border-box;
+    width: 100%;
+    height: 100vh;
+    height: 100dvh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    padding-top: max(2rem, calc(env(safe-area-inset-top, 0px) + 1rem));
+    padding-right: max(2rem, calc(env(safe-area-inset-right, 0px) + 1rem));
+    padding-bottom: max(2rem, calc(env(safe-area-inset-bottom, 0px) + 1rem));
+    padding-left: max(2rem, calc(env(safe-area-inset-left, 0px) + 1rem));
     opacity: 0;
     transition: opacity 200ms cubic-bezier(0.16, 1, 0.3, 1);
   }
@@ -57,9 +68,16 @@ const pathname = Astro.url.pathname;
   [data-mobile-panel][data-open='true'] nav {
     transform: translateY(0);
   }
+  @media (max-height: 36rem) {
+    [data-mobile-panel] nav {
+      justify-content: flex-start;
+    }
+  }
 </style>
 
 <script>
+  import { lockPageScroll, unlockPageScroll } from '@/lib/pageScrollLock';
+
   // Lifecycle assumptions: (1) no ClientRouter / view transitions, so this
   // runs once per full page load; (2) exactly one panel + toggle per page.
   const toggle = document.querySelector<HTMLButtonElement>('[data-mobile-toggle]');
@@ -71,7 +89,7 @@ const pathname = Astro.url.pathname;
       panel.classList.add('flex');
       panel.setAttribute('aria-hidden', 'false');
       toggle.setAttribute('aria-expanded', 'true');
-      document.body.style.overflow = 'hidden';
+      lockPageScroll();
       // Two frames so the display change commits before the transition
       // starts (one rAF can coalesce with the style flush).
       requestAnimationFrame(() => requestAnimationFrame(() => { panel.dataset.open = 'true'; }));
@@ -84,8 +102,8 @@ const pathname = Astro.url.pathname;
       panel.classList.remove('flex');
       panel.setAttribute('aria-hidden', 'true');
       toggle.setAttribute('aria-expanded', 'false');
-      document.body.style.overflow = '';
-      toggle.focus();
+      unlockPageScroll();
+      toggle.focus({ preventScroll: true });
     };
     toggle.addEventListener('click', open);
     closeBtn.addEventListener('click', close);

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -8,8 +8,8 @@ const cta = await getRegistrationCta();
 const pathname = Astro.url.pathname;
 ---
 <header class="bg-navy text-paper border-b border-mint/10">
-  <div class="mx-auto max-w-7xl px-6 py-4 flex items-center justify-between gap-6">
-    <a href="/" class="flex items-center gap-3.5" aria-label="Twin Cities Ski Club home">
+  <div class="nav-inner safe-inline-6 mx-auto max-w-7xl px-6 py-4 flex items-center justify-between gap-6">
+    <a href="/" class="flex min-h-11 items-center gap-3.5" aria-label="Twin Cities Ski Club home">
       <svg width="145" height="22" viewBox="0 0 358.78 54.47" aria-hidden="true">
         <!-- Heritage club logo (from app/static/images/tcsc-logo.svg), recolored
              for the navy bar. Fills are hardcoded on purpose: this mark must
@@ -68,3 +68,12 @@ const pathname = Astro.url.pathname;
     </button>
   </div>
 </header>
+
+<style>
+  /* In standalone mode the nav reaches behind the status bar. Keep its
+     controls below the cutout while preserving the normal 16px rhythm. */
+  .nav-inner {
+    padding-top: max(1rem, calc(env(safe-area-inset-top, 0px) + 0.75rem));
+    padding-bottom: 1rem;
+  }
+</style>

--- a/site/src/components/PhotoMosaic.astro
+++ b/site/src/components/PhotoMosaic.astro
@@ -121,7 +121,7 @@ const composed = sparse && photos.length >= 3;
 {photos.length > 0 && (
   <section class:list={['bg-navy pb-20', !heading && 'pt-20']} data-photo-mosaic>
     {heading && (
-      <div class="max-w-7xl mx-auto px-6 md:px-10 pt-12 md:pt-16">
+      <div class="safe-inline-6-10 max-w-7xl mx-auto px-6 md:px-10 pt-12 md:pt-16">
         {/* Seam: section name in the Trail Report label voice, hairline
             running to the right edge (one device family site-wide). */}
         <div class="flex items-center gap-4">

--- a/site/src/components/PhotoMosaic.client.ts
+++ b/site/src/components/PhotoMosaic.client.ts
@@ -10,6 +10,8 @@
 // src/currentSrc here; that is the small grid-optimized variant, which is
 // exactly the prior shipped bug (305px images stretched fullscreen).
 
+import { lockPageScroll, unlockPageScroll } from '@/lib/pageScrollLock';
+
 type Item = { full: string; fullSrcset: string; alt: string; caption: string };
 
 let bound = false;
@@ -79,7 +81,7 @@ export function init() {
     box!.classList.remove('hidden');
     box!.classList.add('flex');
     box!.setAttribute('aria-hidden', 'false');
-    document.body.style.overflow = 'hidden';
+    lockPageScroll();
     closeBtn!.focus();
   }
 
@@ -87,8 +89,8 @@ export function init() {
     box!.classList.add('hidden');
     box!.classList.remove('flex');
     box!.setAttribute('aria-hidden', 'true');
-    document.body.style.overflow = '';
-    invoker?.focus();
+    unlockPageScroll();
+    invoker?.focus({ preventScroll: true });
     invoker = null;
   }
 

--- a/site/src/components/SectionBand.astro
+++ b/site/src/components/SectionBand.astro
@@ -25,14 +25,14 @@ const seamRule = variant === 'navy' ? 'bg-mint/20' : 'bg-ink/15';
 ---
 <section class={surface}>
   {seam && !isCard && (
-    <div class={'mx-auto ' + innerMax + ' px-6 md:px-10 pt-12 md:pt-16'}>
+    <div class={'safe-inline-6-10 mx-auto ' + innerMax + ' px-6 md:px-10 pt-12 md:pt-16'}>
       <div class="flex items-center gap-4">
         <span class={'text-[11px] tracking-[0.18em] uppercase font-semibold ' + seamText}>{seam}</span>
         <span class={'h-px flex-1 ' + seamRule} aria-hidden="true"></span>
       </div>
     </div>
   )}
-  <div class={isCard ? 'px-6' : undefined}>
+  <div class={isCard ? 'safe-inline-6 px-6' : undefined}>
     <div class={'mx-auto ' + innerMax + ' ' + (isCard ? 'bg-paper text-ink ' : '') + padding}>
       {heading && (
         <h2 class="font-display font-semibold text-4xl md:text-5xl leading-[1.05] mb-4">{heading}</h2>

--- a/site/src/components/WaxEntry.astro
+++ b/site/src/components/WaxEntry.astro
@@ -50,7 +50,7 @@ const hasConditions =
     conditions_snapshot.temp_f != null ||
     conditions_snapshot.wax_used);
 ---
-<article class="mx-auto max-w-3xl px-6 py-12 md:py-16">
+<article class="safe-inline-6 mx-auto max-w-3xl px-6 py-12 md:py-16">
   <div class="text-sm text-slate">{formatted}</div>
   <h1 class="font-display font-semibold text-3xl md:text-5xl text-navy mt-3 leading-tight">{title}</h1>
   {author_name && (

--- a/site/src/components/WaxRoomFeed.astro
+++ b/site/src/components/WaxRoomFeed.astro
@@ -19,7 +19,7 @@ const entries = (await getCollection('wax_entries'))
   .slice(0, 3);
 ---
 <section class="bg-paper text-ink">
-  <div class="mx-auto max-w-7xl px-6 md:px-10">
+  <div class="safe-inline-6-10 mx-auto max-w-7xl px-6 md:px-10">
     {/* Seam: hairline running to the right edge (one device family
         site-wide); no label text, the h2 below names the section. */}
     <div class="pt-12 md:pt-16 flex items-center gap-4">

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -21,6 +21,9 @@ const {
 } = Astro.props;
 
 const isHome = variant === 'home';
+// Every route begins and ends on navy (nav + footer), so browser chrome and
+// the overscroll canvas use that same continuous brand surface.
+const themeColor = '#202A44';
 
 // Build formats expose either a generated filename or a directory slash
 // through Astro.url during prerendering. Public routes remain extensionless,
@@ -44,7 +47,8 @@ const orgSameAs = ['https://www.instagram.com/twincitiesskiclub/'];
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content={themeColor} />
     <title>{title}</title>
     <meta name="description" content={description} />
     {robots && <meta name="robots" content={robots} />}
@@ -88,7 +92,7 @@ const orgSameAs = ['https://www.instagram.com/twincitiesskiclub/'];
       sameAs: orgSameAs,
     })} />
   </head>
-  <body class={`min-h-svh flex flex-col ${isHome ? 'bg-navy text-mint' : 'bg-paper text-ink'}`}>
+  <body class={`site-shell flex flex-col ${isHome ? 'bg-navy text-mint' : 'bg-paper text-ink'}`}>
     {/* Skip link: every page gives its <main> id="main" (the home page and
         InnerPageLayout both do). Visually hidden until keyboard-focused. */}
     <a

--- a/site/src/lib/pageScrollLock.ts
+++ b/site/src/lib/pageScrollLock.ts
@@ -1,0 +1,69 @@
+// Shared viewport lock for fullscreen UI. `overflow: hidden` on body alone is
+// not reliable in mobile Safari, so pin the body at the current scroll offset
+// and lock the root as well. Exact inline values are restored on close.
+type ScrollSnapshot = {
+  scrollY: number;
+  rootOverflow: string;
+  bodyOverflow: string;
+  bodyPosition: string;
+  bodyTop: string;
+  bodyLeft: string;
+  bodyRight: string;
+  bodyWidth: string;
+  bodyPaddingRight: string;
+};
+
+let depth = 0;
+let snapshot: ScrollSnapshot | null = null;
+
+export function lockPageScroll() {
+  depth += 1;
+  if (depth > 1) return;
+
+  const root = document.documentElement;
+  const body = document.body;
+  const scrollY = window.scrollY;
+  const scrollbarWidth = Math.max(0, window.innerWidth - root.clientWidth);
+
+  snapshot = {
+    scrollY,
+    rootOverflow: root.style.overflow,
+    bodyOverflow: body.style.overflow,
+    bodyPosition: body.style.position,
+    bodyTop: body.style.top,
+    bodyLeft: body.style.left,
+    bodyRight: body.style.right,
+    bodyWidth: body.style.width,
+    bodyPaddingRight: body.style.paddingRight,
+  };
+
+  root.style.overflow = 'hidden';
+  body.style.overflow = 'hidden';
+  body.style.position = 'fixed';
+  body.style.top = `-${scrollY}px`;
+  body.style.left = '0';
+  body.style.right = '0';
+  body.style.width = '100%';
+  if (scrollbarWidth > 0) body.style.paddingRight = `${scrollbarWidth}px`;
+}
+
+export function unlockPageScroll() {
+  if (depth === 0) return;
+  depth -= 1;
+  if (depth > 0 || !snapshot) return;
+
+  const root = document.documentElement;
+  const body = document.body;
+  const previous = snapshot;
+  snapshot = null;
+
+  root.style.overflow = previous.rootOverflow;
+  body.style.overflow = previous.bodyOverflow;
+  body.style.position = previous.bodyPosition;
+  body.style.top = previous.bodyTop;
+  body.style.left = previous.bodyLeft;
+  body.style.right = previous.bodyRight;
+  body.style.width = previous.bodyWidth;
+  body.style.paddingRight = previous.bodyPaddingRight;
+  window.scrollTo(0, previous.scrollY);
+}

--- a/site/src/pages/404.astro
+++ b/site/src/pages/404.astro
@@ -35,7 +35,7 @@ const destinations = [
   photoAlt="A freshly groomed ski trail running through a forest coated in snow"
   photoPosition="center 72%"
 >
-  <section class="mx-auto max-w-7xl px-6 py-16 md:py-24">
+  <section class="safe-inline-6 mx-auto max-w-7xl px-6 py-16 md:py-24">
     <div class="grid gap-14 md:grid-cols-12 md:gap-10">
       <div class="md:col-span-6 lg:col-span-5">
         <p class="text-sm font-semibold tracking-[0.08em] text-mint-deep">404 · Page not found</p>

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -35,7 +35,7 @@ const { Content } = await render(about);
   photoAlt="Around fifty TCSC members posing together behind the club banner"
   photoPosition="center 40%"
 >
-  <div class="mx-auto max-w-3xl px-6 py-12">
+  <div class="safe-inline-6 mx-auto max-w-3xl px-6 py-12">
     <div class="prose prose-lg max-w-prose text-ink [&_h2]:font-semibold [&_h2]:tracking-tight [&>p:first-child]:font-semibold [&>p:first-child]:text-xl md:[&>p:first-child]:text-2xl [&>p:first-child]:leading-snug [&>p:first-child]:text-navy">
       <Content />
     </div>

--- a/site/src/pages/community.astro
+++ b/site/src/pages/community.astro
@@ -65,7 +65,7 @@ const groupPhotos: Record<string, { src: ImageMetadata; alt: string; position?: 
   photoAlt="Members in canoes rafted together on a city lake at golden hour"
   photoPosition="center 52%"
 >
-  <div class="mx-auto max-w-3xl px-6 py-12">
+  <div class="safe-inline-6 mx-auto max-w-3xl px-6 py-12">
     <div class="prose prose-lg max-w-prose text-ink">
       <Content />
     </div>

--- a/site/src/pages/dry-tri.astro
+++ b/site/src/pages/dry-tri.astro
@@ -32,7 +32,7 @@ const legs = [
   ]}
 >
   {legs.length === 3 && (
-    <section class="mx-auto max-w-7xl px-6 md:px-10 pt-14 md:pt-20" aria-label="The three legs">
+    <section class="safe-inline-6-10 mx-auto max-w-7xl px-6 md:px-10 pt-14 md:pt-20" aria-label="The three legs">
       <div class="grid grid-cols-3 gap-px bg-ink/10 border border-ink/10">
         {legs.map((l) => (
           <figure class="bg-paper">
@@ -70,7 +70,7 @@ const legs = [
       <p class="mt-4 text-sm text-slate">The 2025 format. Each leg starts and ends at the transition zone in the Parley Lake lot.</p>
     </SectionBand>
   )}
-  <div class="mx-auto max-w-3xl px-6 pb-12">
+  <div class="safe-inline-6 mx-auto max-w-3xl px-6 pb-12">
     <div class="prose prose-lg max-w-prose text-ink">
       <Content />
     </div>

--- a/site/src/pages/extra-training-fun.astro
+++ b/site/src/pages/extra-training-fun.astro
@@ -26,7 +26,7 @@ const photos = [
   subhead={d.intro}
   facts={[{ value: '2022', label: 'Member-led since' }]}
 >
-  <div class="mx-auto max-w-3xl px-6 py-12">
+  <div class="safe-inline-6 mx-auto max-w-3xl px-6 py-12">
     <div class="prose prose-lg max-w-prose text-ink">
       <Content />
     </div>
@@ -47,7 +47,7 @@ const photos = [
     </SectionBand>
   )}
   {photos.length > 0 && (
-    <section class="mx-auto max-w-7xl px-6 md:px-10 py-14 md:py-20" aria-label="Photos">
+    <section class="safe-inline-6-10 mx-auto max-w-7xl px-6 md:px-10 py-14 md:py-20" aria-label="Photos">
       <div class="grid gap-6 md:grid-cols-2">
         {photos.map((p) => (
           <figure>

--- a/site/src/pages/racing.astro
+++ b/site/src/pages/racing.astro
@@ -41,13 +41,13 @@ const raceStrip = [
   photoAlt="Six members in race bibs, arms around each other, in frosty woods before a start"
   photoPosition="center 30%"
 >
-  <div class="mx-auto max-w-3xl px-6 py-12">
+  <div class="safe-inline-6 mx-auto max-w-3xl px-6 py-12">
     <div class="prose prose-lg max-w-prose text-ink">
       <Content />
     </div>
   </div>
   {races.length > 0 && (
-    <section class="mx-auto max-w-3xl px-6 pb-12">
+    <section class="safe-inline-6 mx-auto max-w-3xl px-6 pb-12">
       <h2 class="font-display font-semibold text-3xl text-navy">Races</h2>
       <div class="mt-6 divide-y divide-ink/10">
         {races.map((r) => (

--- a/site/src/pages/sponsors.astro
+++ b/site/src/pages/sponsors.astro
@@ -23,7 +23,7 @@ const mailtoHref = `mailto:${page.data.contact_email}`;
   headline={page.data.headline}
   subhead={page.data.intro}
 >
-  <div class="mx-auto max-w-5xl px-6 md:px-10 py-16 md:py-20">
+  <div class="safe-inline-6-10 mx-auto max-w-5xl px-6 md:px-10 py-16 md:py-20">
     <SponsorWall headingLevel="h2" />
   </div>
 
@@ -104,7 +104,7 @@ const mailtoHref = `mailto:${page.data.contact_email}`;
     </div>
   </SectionBand>
 
-  <div class="bg-paper px-6 md:px-10 pb-8">
+  <div class="safe-inline-6-10 bg-paper px-6 md:px-10 pb-8">
     <p class="mx-auto max-w-7xl text-base leading-relaxed text-slate">
       {page.data.disclosure}
     </p>

--- a/site/src/pages/trips/index.astro
+++ b/site/src/pages/trips/index.astro
@@ -9,7 +9,7 @@ import TripsTable from '@/components/TripsTable.astro';
   headline="Trips"
   subhead="Sisu Ski Fest, the Birkie, the Prebirkie, the Great Bear Chase. Plus training trips and team weekends."
 >
-  <div class="mx-auto max-w-4xl px-6 py-12">
+  <div class="safe-inline-6 mx-auto max-w-4xl px-6 py-12">
     <TripsTable />
   </div>
 </InnerPageLayout>

--- a/site/src/pages/wax-room/index.astro
+++ b/site/src/pages/wax-room/index.astro
@@ -15,7 +15,7 @@ const entries = (await getCollection('wax_entries')).sort(
   headline="The Wax Room"
   subhead="Conditions, wax notes, race-day prep, technique. Field reports from TCSC coaches and members."
 >
-  <div class="mx-auto max-w-3xl px-6 py-12 md:py-16">
+  <div class="safe-inline-6 mx-auto max-w-3xl px-6 py-12 md:py-16">
     {entries.length === 0 ? (
       <p class="text-slate">No entries yet.</p>
     ) : (

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -31,12 +31,37 @@
   font-display: swap;
 }
 
+/* Mobile Safari exposes the root canvas during overscroll and around its
+   safe areas. Navy matches every route's nav and footer, so neither edge can
+   flash a white strip even when the page content itself is paper. */
 html {
   font-family: 'ArchivoVariable', system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background: oklch(0.985 0.003 90);
+  background: oklch(0.25 0.06 260);
   color: oklch(0.18 0.04 260);
+}
+
+/* 100vh is the compatibility fallback. dvh tracks retracting mobile browser
+   chrome so short pages continue to cover the visible viewport. */
+.site-shell {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+/* Shared content gutters that expand only when a device cutout needs more
+   room. Full-bleed surface backgrounds remain untouched. */
+.safe-inline-6,
+.safe-inline-6-10 {
+  --safe-inline-gutter: 1.5rem;
+  padding-left: max(var(--safe-inline-gutter), calc(env(safe-area-inset-left, 0px) + 0.75rem));
+  padding-right: max(var(--safe-inline-gutter), calc(env(safe-area-inset-right, 0px) + 0.75rem));
+}
+
+@media (min-width: 48rem) {
+  .safe-inline-6-10 {
+    --safe-inline-gutter: 2.5rem;
+  }
 }
 
 /* Focus-visible baseline (DESIGN.md): always-visible 2px ring, mint on navy


### PR DESCRIPTION
## Summary

- theme mobile browser chrome and overscroll canvas navy to remove the white bottom bar
- add safe-area-aware gutters, footer padding, overlays, and stable mobile viewport sizing
- make short-screen navigation scrollable and restore page position after closing fullscreen UI
- bring shared mobile navigation controls up to the 44px touch-target standard

## Verification

- npm run check
- npm run build
- npm run test:sponsors
- WebKit and Chromium mobile checks across all 11 public routes at 320x568 and 667x375 with no overflow failures