### PR TITLE
Website 2.1 refinement

### DIFF
--- a/docs/superpowers/plans/2026-07-19-website-2-1-refinement.md
+++ b/docs/superpowers/plans/2026-07-19-website-2-1-refinement.md
@@ -1,0 +1,193 @@
+# Website 2.1 Refinement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to execute this plan task by task in the current session.
+
+**Goal:** Refine the current TCSC marketing site without changing its established visual system: publish one useful Wax Room contingency article, make the conditions strip season-aware, remove the tablet-width navigation overflow, and correct a small set of misleading or overly corporate public copy.
+
+**Architecture:** Keep the existing Astro content collections, page compositions, and navy/paper visual rhythm. Add one small pure TypeScript decision helper for the live-conditions client so season logic is testable without a browser. Make the remaining changes through existing content fields, breakpoints, and `InnerPageLayout` facts rather than introducing new UI patterns.
+
+**Tech Stack:** Astro 7, TypeScript, Tailwind CSS 4, Markdoc, Node's built-in test runner, pytest/Playwright for final browser verification.
+
+## Global Constraints
+
+- This is a tick release, not a redesign. Preserve the current typography, color palette, photography, page compositions, and interaction style.
+- Work only in `/Users/rob/env/tcsc-trips/.worktrees/site-2-1-refinement` on branch `feat/site-2-1-refinement`.
+- Follow red-green-refactor for each task: add the smallest failing automated test, observe the expected failure, implement, then rerun the focused test.
+- Do not change the server wax-temperature thresholds. Red wax can be valid above freezing when snow exists; the defect is that a successful July weather response bypasses the client's dryland presentation.
+- April through October inclusive must render the dryland treatment even when the API succeeds. November through March must retain the current live conditions behavior.
+- Do not attribute the Wax Room article to an individual without explicit publication approval. Omit `author_name`, photo, and conditions snapshot.
+- Do not publish expired prices, discounts, participant names, speed promises, or current shop availability in the Wax Room article.
+- Do not invent facts. Copy changes below use existing public content and the club's private-Slack coordination model.
+- Keep all links truthful and useful. The global coming-soon registration CTA must point to confirmed dates on the home page, and the Dry Tri page must not send visitors to stale 2025 registration.
+- Leave the coach-photo/profile follow-up and trip collection untouched; both require new assets or facts.
+- Use `apply_patch` for hand-authored file changes. Preserve unrelated work.
+
+## Task 1: Make live conditions season-aware on successful API responses
+
+**Files:**
+
+- Create: `site/src/lib/conditionsDisplayMode.ts`
+- Create: `site/tests/conditionsDisplayMode.test.mjs`
+- Modify: `site/src/components/LiveConditions.client.ts`
+
+### Test first
+
+- [ ] Create `site/tests/conditionsDisplayMode.test.mjs` using `node:test` and `node:assert/strict`.
+- [ ] Import the pure helper from `../src/lib/conditionsDisplayMode.ts`.
+- [ ] Cover these exact cases:
+  - a healthy, non-empty payload at `2026-07-19T12:00:00-05:00` resolves to `off-season`;
+  - an error/empty payload in July also resolves to `off-season`;
+  - a healthy, non-empty payload at `2027-01-15T12:00:00-06:00` resolves to `live`;
+  - an error/empty payload in January resolves to `unavailable`.
+- [ ] Run `cd site && node --test tests/conditionsDisplayMode.test.mjs` and confirm it fails because the helper does not exist.
+
+### Implement
+
+- [ ] Add a pure exported `conditionsDisplayMode(payload, at = new Date())` helper returning the literal union `off-season | live | unavailable`.
+- [ ] Define dryland season as local calendar months April through October inclusive.
+- [ ] In `LiveConditions.client.ts`, use the helper before restoring or filling venue cells. A healthy July response must enter the same dryland presentation as a July fetch failure.
+- [ ] Keep one shared rendering path for the dryland/unavailable quiet state; do not duplicate the DOM mutation block.
+- [ ] Preserve the current presentation contract:
+  - venue temperatures, wax labels/chips, report links, and grooming lines are hidden in dryland season;
+  - compact/mobile output contains one `Dryland season` label;
+  - prominent desktop retains the `98.6°` Birkie reading;
+  - the prominent stamp says `● Trail reports come back with the snow`;
+  - winter live payloads still render venue names, temperatures, wax, report links, grooming, and update time.
+
+### Verify
+
+- [ ] Rerun `cd site && node --test tests/conditionsDisplayMode.test.mjs` and confirm all cases pass.
+- [ ] Run `cd site && npx astro check`.
+- [ ] With a local Astro server and an intercepted healthy July payload containing 87°F and `Red wax · klister conditions`, verify the rendered home page contains one dryland message and no visible red-wax or venue-temperature output.
+- [ ] Repeat with a January payload and verify live venue/wax output remains visible.
+- [ ] Commit only this task's implementation and test.
+
+## Task 2: Keep the hamburger navigation through tablet widths
+
+**Files:**
+
+- Create: `site/tests/responsiveNav.test.mjs`
+- Modify: `site/src/components/Nav.astro`
+
+### Test first
+
+- [ ] Create a source contract test that reads `Nav.astro` and asserts:
+  - the primary nav uses `hidden lg:flex`;
+  - the CTA wrapper uses `hidden lg:flex`;
+  - the menu button uses `lg:hidden`;
+  - the old `hidden md:flex` and `md:hidden` navigation-mode classes are absent.
+- [ ] Run `cd site && node --test tests/responsiveNav.test.mjs` and confirm it fails on the current `md` breakpoint.
+
+### Implement
+
+- [ ] Change only the navigation-mode breakpoints from `md` to `lg`; preserve spacing, active-state treatment, button styling, markup, and link order.
+- [ ] Do not tune fixed widths around the current CTA label.
+
+### Verify
+
+- [ ] Rerun the focused Node test.
+- [ ] Build the site and, at viewport widths 768, 782, 783, and 1024, assert `document.documentElement.scrollWidth === document.documentElement.clientWidth` on every public route.
+- [ ] At 768, 782, and 783 verify exactly the hamburger navigation is visible; at 1024 verify exactly the desktop navigation is visible.
+- [ ] Open and close the mobile menu once at 783 to confirm focus, Escape, and scroll-lock behavior remain intact.
+- [ ] Commit only this task's implementation and test.
+
+## Task 3: Publish the contingency Wax Room article
+
+**Files:**
+
+- Create: `site/src/content/wax_entries/stone-grind-or-hotbox.mdoc`
+- Create: `site/tests/waxRoomEntry.test.mjs`
+
+### Test first
+
+- [ ] Create a test that requires the entry file and, after an Astro build, verifies:
+  - the home page, Wax Room index, and detail route all contain `Stone Grind or Hotbox? When Skis Need a Second Wind`;
+  - the detail route is `/wax-room/stone-grind-or-hotbox/`;
+  - the source has date `2026-07-19` and no `author_name`, `photo`, or `conditions_snapshot` field;
+  - the source includes the headings `What a stone grind changes`, `What a hotbox changes`, `Five useful things to tell the shop`, and `The short version`;
+  - the article contains no dollar price, discount claim, or em dash.
+- [ ] Run the focused test and confirm it fails because the entry does not exist.
+
+### Implement
+
+- [ ] Add the following frontmatter exactly, with no byline or image metadata:
+
+```yaml
+---
+slug: Stone Grind or Hotbox? When Skis Need a Second Wind
+date: 2026-07-19
+lede: >-
+  Last winter, eleven TCSC pairs headed to the shop together. Here is how to
+  think about structure, wax conditioning, or both.
+---
+```
+
+- [ ] Write a concise field guide grounded in the December 2025 TCSC group service order:
+  - open with the member question and the eleven-pair response;
+  - explain that the batch used Finn Sisu's universal grind for a Midwest/manmade mix and offered hotboxing for skis without regular waxing;
+  - distinguish permanent base structure from wax conditioning;
+  - explain that fine/medium/coarse/universal are snow-use choices, not a slow-to-fast ranking;
+  - give five concrete facts a skier should tell a shop;
+  - close with the ski-specific rule: grind when structure needs renewal, ask about hotboxing when conditioning may help, and choose both only when both jobs make sense.
+- [ ] Keep the voice member-like, compact, practical, and non-promotional. Use no em dashes or exclamation points.
+
+### Verify
+
+- [ ] Run `cd site && npm run build` and confirm the Wax Room collection warning is gone and the new detail page is generated.
+- [ ] Run `cd site && node --test tests/waxRoomEntry.test.mjs`.
+- [ ] Inspect the home feed, index, and detail page at 390px and 1440px. Confirm title wrapping, heading rhythm, readable measure, and adjacent section seams fit the current design.
+- [ ] Commit only this task's entry and test.
+
+## Task 4: Correct registration, event, membership, mission, race, and sponsor copy
+
+**Files:**
+
+- Create: `site/tests/contentRefinements.test.mjs`
+- Modify: `site/src/content/pages/home.yaml`
+- Modify: `site/src/pages/index.astro`
+- Modify: `site/src/components/CTAStrip.astro`
+- Modify: `site/src/content/pages/dry_tri.mdoc`
+- Modify: `site/src/content/pages/extra_training.mdoc`
+- Modify: `site/src/content/pages/community.mdoc`
+- Modify: `site/src/content/pages/racing.mdoc`
+- Modify: `site/src/pages/sponsors.astro`
+
+### Test first
+
+- [ ] Add a source-and-built-output contract test for every exact change below, and first run it against current sources to observe failures.
+
+### Implement exact copy and wiring
+
+- [ ] In `home.yaml`, set:
+  - `cta_coming_soon_label: Fall registration dates`
+  - `cta_coming_soon_url: /#registration`
+  - mission paragraph: `TCSC is a 501(c)(3) nonprofit where young adult skiers train together twice a week, race if they want to, travel to Midwest ski weekends, volunteer, and organize workouts and socials beyond practice.`
+- [ ] Add an optional `id` prop to `CTAStrip.astro`, forward it to the component's `<section>`, and pass `id="registration"` to the home-page CTA strip. Preserve every existing style class.
+- [ ] Keep the existing home CTA subhead with the confirmed distinction: `Returning members Aug 28; new members Sep 3.`
+- [ ] In `dry_tri.mdoc`, remove `register_url` and replace the 2026 paragraph with: `Planning for 2026 is underway. The date and registration details will be posted here when confirmed.` Preserve the 2025 recap and results link.
+- [ ] In the Extra Training intro, replace `Everyone is welcome` with `Every member is welcome`.
+- [ ] In Community's Extra Training detail, replace `No signup, everyone welcome.` with `No signup; all members welcome.`
+- [ ] In Racing, replace `Two TCSC teams participated this year.` with `Two TCSC teams participated in 2026.`
+- [ ] On Sponsors, pass `facts={[{ value: '501(c)(3) nonprofit', label: 'Status' }]}` to `InnerPageLayout` so nonprofit status appears in the masthead.
+
+### Verify
+
+- [ ] Run the focused contract test and confirm it passes.
+- [ ] Run a production build and assert:
+  - the coming-soon CTA label links to `/#registration` and the target exists;
+  - both Aug 28 and Sep 3 are visible in the registration section;
+  - the Dry Tri page contains no 2026 registration-open promise and no stale `/tri` registration link;
+  - the sponsor masthead includes `501(c)(3) nonprofit`;
+  - rejected phrases `dedicated to fostering`, `promoting a healthy lifestyle`, `this year`, and bare `everyone welcome` are absent from public content.
+- [ ] Inspect home, Dry Tri, Extra Training, Racing, Community, and Sponsors at 390px and 1440px for clean wraps and unchanged hierarchy.
+- [ ] Commit only this task's implementation and test.
+
+## Final Integration and Review
+
+- [ ] Run all new Node tests together after a fresh production build.
+- [ ] Run `cd site && npx astro check` and require zero errors, warnings, and hints.
+- [ ] Run the existing sponsor suite.
+- [ ] Run `/Users/rob/env/tcsc-trips/env/bin/pytest tests/conditions tests/wix_scrape -q` and preserve the 74-test green baseline.
+- [ ] Crawl every built public route at 320, 390, 768, 782, 783, 1024, and 1440 widths for horizontal overflow, one H1, duplicate IDs, missing image alt text, and broken internal links.
+- [ ] Review the entire branch against `main`, resolve all Critical/Important findings, and rerun affected tests.
+- [ ] Record the remaining evidence-gated follow-ups: a better KJ portrait/profile source and explicit public-guest policy if club leadership wants nonmembers at informal workouts.

--- a/docs/superpowers/plans/2026-07-19-website-2-1-refinement.md
+++ b/docs/superpowers/plans/2026-07-19-website-2-1-refinement.md
@@ -160,7 +160,7 @@ lede: >-
 
 - [ ] In `home.yaml`, set:
   - `cta_coming_soon_label: Fall registration dates`
-  - `cta_coming_soon_url: https://tcsc.ski/#registration`
+  - `cta_coming_soon_url: https://twincitiesskiclub.org/#registration`
   - mission paragraph: `TCSC is a 501(c)(3) nonprofit where young adult skiers train together twice a week, race if they want to, travel to Midwest ski weekends, volunteer, and organize workouts and socials beyond practice.`
 - [ ] Add an optional `id` prop to `CTAStrip.astro`, forward it to the component's `<section>`, and pass `id="registration"` to the home-page CTA strip. Preserve every existing style class.
 - [ ] Keep the existing home CTA subhead with the confirmed distinction: `Returning members Aug 28; new members Sep 3.`
@@ -174,7 +174,7 @@ lede: >-
 
 - [ ] Run the focused contract test and confirm it passes.
 - [ ] Run a production build and assert:
-  - the coming-soon CTA label links to `https://tcsc.ski/#registration` and the target exists;
+  - the coming-soon CTA label links to `https://twincitiesskiclub.org/#registration` and the target exists;
   - both Aug 28 and Sep 3 are visible in the registration section;
   - the Dry Tri page contains no 2026 registration-open promise and no stale `/tri` registration link;
   - the sponsor masthead includes `501(c)(3) nonprofit`;

--- a/docs/superpowers/plans/2026-07-19-website-2-1-refinement.md
+++ b/docs/superpowers/plans/2026-07-19-website-2-1-refinement.md
@@ -160,7 +160,7 @@ lede: >-
 
 - [ ] In `home.yaml`, set:
   - `cta_coming_soon_label: Fall registration dates`
-  - `cta_coming_soon_url: /#registration`
+  - `cta_coming_soon_url: https://tcsc.ski/#registration`
   - mission paragraph: `TCSC is a 501(c)(3) nonprofit where young adult skiers train together twice a week, race if they want to, travel to Midwest ski weekends, volunteer, and organize workouts and socials beyond practice.`
 - [ ] Add an optional `id` prop to `CTAStrip.astro`, forward it to the component's `<section>`, and pass `id="registration"` to the home-page CTA strip. Preserve every existing style class.
 - [ ] Keep the existing home CTA subhead with the confirmed distinction: `Returning members Aug 28; new members Sep 3.`
@@ -174,7 +174,7 @@ lede: >-
 
 - [ ] Run the focused contract test and confirm it passes.
 - [ ] Run a production build and assert:
-  - the coming-soon CTA label links to `/#registration` and the target exists;
+  - the coming-soon CTA label links to `https://tcsc.ski/#registration` and the target exists;
   - both Aug 28 and Sep 3 are visible in the registration section;
   - the Dry Tri page contains no 2026 registration-open promise and no stale `/tri` registration link;
   - the sponsor masthead includes `501(c)(3) nonprofit`;

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -22,6 +22,7 @@
         "@tailwindcss/vite": "^4.3.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "jsdom": "29.1.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "tailwindcss": "^4.3.2",
@@ -88,6 +89,57 @@
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/check": {
       "version": "0.9.9",
@@ -820,6 +872,19 @@
       "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
       "license": "MIT"
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bruits/satteri-darwin-arm64": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@bruits/satteri-darwin-arm64/-/satteri-darwin-arm64-0.9.5.tgz",
@@ -1003,6 +1068,146 @@
       },
       "engines": {
         "node": ">= 20.12.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emmetio/abbreviation": {
@@ -1624,6 +1829,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -5554,6 +5777,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -6029,6 +6262,20 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6264,6 +6511,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -6667,6 +6927,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
@@ -6905,6 +7178,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
@@ -6951,6 +7231,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -8563,6 +8884,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/partysocket": {
       "version": "0.0.22",
       "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-0.0.22.tgz",
@@ -8799,6 +9133,16 @@
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/radix3": {
@@ -9118,6 +9462,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -9418,6 +9775,13 @@
         "url": "https://opencollective.com/svgo"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
@@ -9497,6 +9861,52 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -9571,6 +9981,16 @@
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -10294,10 +10714,75 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/wonka": {
       "version": "6.3.6",
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.6.tgz",
       "integrity": "sha512-MXH+6mDHAZ2GuMpgKS055FR6v0xVP3XwquxIMYXgiW+FejHQlMGlvVRZT4qMCxR+bEo/FCtIdKxwej9WV3YQag==",
+      "license": "MIT"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/xxhash-wasm": {

--- a/site/package.json
+++ b/site/package.json
@@ -29,6 +29,7 @@
     "@tailwindcss/vite": "^4.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "jsdom": "29.1.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "tailwindcss": "^4.3.2",

--- a/site/package.json
+++ b/site/package.json
@@ -11,6 +11,7 @@
     "build": "astro build",
     "preview": "astro preview --port 4321",
     "check": "astro check",
+    "test:refinement": "npm run build && node --test tests/conditionsDisplayMode.test.mjs tests/responsiveNav.test.mjs tests/waxRoomEntry.test.mjs tests/contentRefinements.test.mjs",
     "test:sponsors": "npm run build && node --test tests/sponsorTiers.test.mjs tests/sponsorSchemaContracts.test.mjs tests/sponsorWallBuild.test.mjs tests/sponsors-page.test.mjs"
   },
   "dependencies": {

--- a/site/src/components/CTAStrip.astro
+++ b/site/src/components/CTAStrip.astro
@@ -4,10 +4,11 @@ interface Props {
   subhead?: string;
   cta_label: string;
   cta_url: string;
+  id?: string;
 }
-const { heading, subhead, cta_label, cta_url } = Astro.props;
+const { heading, subhead, cta_label, cta_url, id } = Astro.props;
 ---
-<section class="bg-navy border-t-[3px] border-coral text-paper">
+<section id={id} class="bg-navy border-t-[3px] border-coral text-paper">
   <div class="safe-inline-6 mx-auto max-w-7xl px-6 py-16 md:py-20 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
     <div>
       <h2 class="font-display font-semibold text-3xl md:text-4xl text-mint leading-tight">{heading}</h2>

--- a/site/src/components/LiveConditions.client.ts
+++ b/site/src/components/LiveConditions.client.ts
@@ -1,3 +1,8 @@
+import {
+  conditionsDisplayMode,
+  type ConditionsDisplayMode,
+} from '@/lib/conditionsDisplayMode';
+
 type LocResp = {
   id: string;
   name: string;
@@ -29,14 +34,15 @@ async function fetchAndRender(root: HTMLElement) {
     const data: Resp = await r.json();
     renderInto(root, data);
   } catch {
-    renderFailure(root);
+    renderQuiet(root, conditionsDisplayMode(null));
   }
 }
 
 function renderInto(root: HTMLElement, data: Resp) {
-  // Flask's defensive error body is {updated_at: null, locations: [], error}.
-  if (data.error || !Array.isArray(data.locations) || data.locations.length === 0) {
-    return renderFailure(root);
+  const mode = conditionsDisplayMode(data);
+  if (mode !== 'live') {
+    renderQuiet(root, mode);
+    return;
   }
   // Restore venue cells that were hidden during off-season, and remove any
   // injected dryland label so the grid layout comes back cleanly.
@@ -93,12 +99,12 @@ function renderInto(root: HTMLElement, data: Resp) {
   updateStamp(root);
 }
 
-function renderFailure(root: HTMLElement) {
-  // Total failure: say it once in the stamp; cells go quiet ("No report")
-  // instead of repeating the error four times. Off-season (April-October),
-  // the strip talks like a member instead of erroring: no snow is not an
-  // outage.
-  const offSeason = new Date().getMonth() + 1 >= 4 && new Date().getMonth() + 1 <= 10;
+function renderQuiet(root: HTMLElement, mode: ConditionsDisplayMode) {
+  // Unavailable conditions say it once in the stamp; cells go quiet ("No
+  // report") instead of repeating the error four times. Off-season
+  // (April-October), healthy payloads and failures share this dryland path:
+  // no snow is not an outage.
+  const offSeason = mode === 'off-season';
   root.querySelectorAll<HTMLElement>('[data-location]').forEach((el) => {
     // Clear temp so the server-rendered middot placeholder does not dangle.
     setText(el, '[data-temp]', '');

--- a/site/src/components/LiveConditions.client.ts
+++ b/site/src/components/LiveConditions.client.ts
@@ -44,15 +44,7 @@ function renderInto(root: HTMLElement, data: Resp) {
     renderQuiet(root, mode);
     return;
   }
-  // Restore venue cells that were hidden during off-season, and remove any
-  // injected dryland label so the grid layout comes back cleanly.
-  root.querySelectorAll<HTMLElement>('[data-location]').forEach((el) => {
-    el.hidden = false;
-    // Inline display is the actual hide mechanism (the compact cells carry a
-    // `flex` class that out-specifies the UA [hidden] rule).
-    el.style.removeProperty('display');
-  });
-  root.querySelector('[data-dryland-label]')?.remove();
+  resetSeasonalPresentation(root);
   // The groomed line rides below the wax line and is prominent-only (the
   // compact variant keeps one line per venue); the stamp only exists there.
   const isCompact = !root.querySelector('[data-updated]');
@@ -105,6 +97,7 @@ function renderQuiet(root: HTMLElement, mode: ConditionsDisplayMode) {
   // (April-October), healthy payloads and failures share this dryland path:
   // no snow is not an outage.
   const offSeason = mode === 'off-season';
+  resetSeasonalPresentation(root);
   root.querySelectorAll<HTMLElement>('[data-location]').forEach((el) => {
     // Clear temp so the server-rendered middot placeholder does not dangle.
     setText(el, '[data-temp]', '');
@@ -159,6 +152,18 @@ function renderQuiet(root: HTMLElement, mode: ConditionsDisplayMode) {
     stamp.textContent = stampText;
   }
   root.dataset.filled = 'true';
+}
+
+function resetSeasonalPresentation(root: HTMLElement) {
+  // Every render starts from winter-visible venue cells. Off-season can then
+  // deliberately hide them again without leaking that state into November.
+  root.querySelectorAll<HTMLElement>('[data-location]').forEach((el) => {
+    el.hidden = false;
+    // Inline display is the actual hide mechanism (the compact cells carry a
+    // `flex` class that out-specifies the UA [hidden] rule).
+    el.style.removeProperty('display');
+  });
+  root.querySelector('[data-dryland-label]')?.remove();
 }
 
 function updateStamp(root: HTMLElement) {

--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -35,7 +35,7 @@ const pathname = Astro.url.pathname;
       </svg>
     </a>
 
-    <nav aria-label="Primary" class="hidden md:flex items-center gap-7 text-sm text-paper/85">
+    <nav aria-label="Primary" class="hidden lg:flex items-center gap-7 text-sm text-paper/85">
       {links.map((l) => {
         const active = isActiveLink(l.href, pathname);
         return (
@@ -51,12 +51,12 @@ const pathname = Astro.url.pathname;
       })}
     </nav>
 
-    <div class="hidden md:flex items-center gap-5">
+    <div class="hidden lg:flex items-center gap-5">
       <CtaForState {...cta} />
     </div>
 
     <button
-      class="md:hidden p-2.5 -m-2.5 text-paper"
+      class="lg:hidden p-2.5 -m-2.5 text-paper"
       aria-label="Open menu"
       aria-expanded="false"
       aria-controls="mobile-nav-panel"

--- a/site/src/content/pages/community.mdoc
+++ b/site/src/content/pages/community.mdoc
@@ -86,7 +86,7 @@ takeaways:
   - group: Extra training fun
     items:
       - line: Member-organized workouts, most days of the week
-        detail: Track mornings, long rollerskis, open-water swims. No signup, everyone welcome.
+        detail: Track mornings, long rollerskis, open-water swims. No signup; all members welcome.
         href: /extra-training-fun
       - line: Thursday Track Club and The Sunday Roll
         detail: Both run throughout dryland season.

--- a/site/src/content/pages/dry_tri.mdoc
+++ b/site/src/content/pages/dry_tri.mdoc
@@ -17,7 +17,6 @@ ride_photo: ../../assets/images/photos/dry-tri-rider.jpg
 ride_photo_alt: A smiling rider in a beanie on the bike leg, fall color behind her
 run_photo: ../../assets/images/photos/dry-tri-runner.jpg
 run_photo_alt: A runner with mud-spattered legs mid-stride on the run leg
-register_url: https://tcsc.ski/tri
 results_url: https://my.raceresult.com/361087/results
 ---
 ## 2025
@@ -28,4 +27,4 @@ The event was run by about twenty club volunteers covering parking, course marsh
 
 ## 2026
 
-Registration for the 2026 race opens this summer at [tcsc.ski/tri](https://tcsc.ski/tri). TCSC members race at a discount.
+Planning for 2026 is underway. The date and registration details will be posted here when confirmed.

--- a/site/src/content/pages/extra_training.mdoc
+++ b/site/src/content/pages/extra_training.mdoc
@@ -3,7 +3,7 @@ headline: Extra training fun
 intro: >-
   Coached practices run Tuesday and Thursday. The rest of the week, members
   organize their own workouts: track mornings, long rollerskis, open-water
-  swims. Everyone is welcome, and there is no signup.
+  swims. Every member is welcome, and there is no signup.
 fixtures:
   - name: Thursday Track Club
     when: Thursdays at 7 AM, spring through fall

--- a/site/src/content/pages/home.yaml
+++ b/site/src/content/pages/home.yaml
@@ -6,12 +6,11 @@ hero_image_alt: >-
 registration_state: coming_soon
 cta_open_label: Register for the season
 cta_open_url: https://tcsc.ski/
-cta_coming_soon_label: Registration opens Aug 28
-cta_coming_soon_url: https://tcsc.ski/
+cta_coming_soon_label: Fall registration dates
+cta_coming_soon_url: https://tcsc.ski/#registration
 cta_closed_label: How to register
 cta_closed_url: https://tcsc.ski/
 mission_paragraph: >-
-  Twin Cities Ski Club is a 501(c)(3) nonprofit dedicated to fostering a
-  supportive community for young adults (ages 21-35) by promoting a healthy
-  lifestyle through cross-country ski training sessions and educational
-  programming.
+  TCSC is a 501(c)(3) nonprofit where young adult skiers train together twice a
+  week, race if they want to, travel to Midwest ski weekends, volunteer, and
+  organize workouts and socials beyond practice.

--- a/site/src/content/pages/home.yaml
+++ b/site/src/content/pages/home.yaml
@@ -7,7 +7,7 @@ registration_state: coming_soon
 cta_open_label: Register for the season
 cta_open_url: https://tcsc.ski/
 cta_coming_soon_label: Fall registration dates
-cta_coming_soon_url: https://tcsc.ski/#registration
+cta_coming_soon_url: https://twincitiesskiclub.org/#registration
 cta_closed_label: How to register
 cta_closed_url: https://tcsc.ski/
 mission_paragraph: >-

--- a/site/src/content/pages/racing.mdoc
+++ b/site/src/content/pages/racing.mdoc
@@ -23,7 +23,7 @@ races:
   - name: Tour de Finn
     location: Twin Cities metro
     date: Local series
-    notes: Two TCSC teams participated this year.
+    notes: Two TCSC teams participated in 2026.
   - name: TCSC Dry Tri
     location: Carver Park Reserve
     date: Late October

--- a/site/src/content/wax_entries/stone-grind-or-hotbox.mdoc
+++ b/site/src/content/wax_entries/stone-grind-or-hotbox.mdoc
@@ -1,0 +1,33 @@
+---
+slug: Stone Grind or Hotbox? When Skis Need a Second Wind
+date: 2026-07-19
+lede: >-
+  Last winter, eleven TCSC pairs headed to the shop together. Here is how to
+  think about structure, wax conditioning, or both.
+---
+
+In December 2025, one TCSC member asked a practical question: who had skis that needed a second wind? Eleven pairs joined a coordinated Finn Sisu service order.
+
+For that batch, the practical recommendation was Finn Sisu's universal grind for a Midwest/manmade mix. Hotboxing was optional for skis that had not been waxed regularly. The two services do different jobs, so that order is a useful example rather than a prescription for every ski.
+
+## What a stone grind changes
+
+A stone grind permanently cuts structure into the ski base. It is physical base work, used when the existing structure needs to be renewed or matched to the snow the ski will usually see.
+
+Fine, medium, coarse, and universal describe snow-use choices. They are not a slow-to-fast ranking. A finer structure suits a different snow range than a coarser one, while a universal pattern covers a broader mix. Tell the shop where and when you ski so it can help choose the appropriate family.
+
+## What a hotbox changes
+
+A hotbox uses controlled warmth to condition the base with wax over time. It does not cut a new structure and it does not replace a grind. It is a complementary waxing step that may make sense for a ski that has gone without regular waxing.
+
+## Five useful things to tell the shop
+
+1. Where the ski is used most, including whether the snow is mainly natural, manmade, or a mix.
+2. The usual snow temperature and moisture range, not just the forecast for one outing.
+3. When the base was last ground and which structure it received, if known.
+4. How regularly the ski has been waxed and how the base has been cared for between uses.
+5. What prompted the service request, such as worn structure, base damage, or a dry-looking base.
+
+## The short version
+
+Grind when a ski's structure needs renewal. Ask about hotboxing when its wax conditioning may help. Choose both only when both jobs make sense for that ski.

--- a/site/src/content/wax_entries/stone-grind-or-hotbox.mdoc
+++ b/site/src/content/wax_entries/stone-grind-or-hotbox.mdoc
@@ -14,7 +14,7 @@ For that batch, the practical recommendation was Finn Sisu's universal grind for
 
 A stone grind permanently cuts structure into the ski base. It is physical base work, used when the existing structure needs to be renewed or matched to the snow the ski will usually see.
 
-Fine, medium, coarse, and universal describe snow-use choices. They are not a slow-to-fast ranking. A finer structure suits a different snow range than a coarser one, while a universal pattern covers a broader mix. Tell the shop where and when you ski so it can help choose the appropriate family.
+Shop labels vary. Fine, medium, and coarse commonly describe structure grades for different snow ranges. Universal is often a shop's broader-use pattern or menu label, not a fourth grade on the same scale. None of these labels is a slow-to-fast ranking. A finer structure suits a different snow range than a coarser one, while a universal pattern covers a broader mix. Tell the shop where and when you ski so it can help choose the appropriate family.
 
 ## What a hotbox changes
 
@@ -22,7 +22,7 @@ A hotbox uses controlled warmth to condition the base with wax over time. It doe
 
 ## Five useful things to tell the shop
 
-1. Where the ski is used most, including whether the snow is mainly natural, manmade, or a mix.
+1. Whether the ski is classic or skate, because technique affects structure selection, and where it is used most, including whether the snow is mainly natural, manmade, or a mix.
 2. The usual snow temperature and moisture range, not just the forecast for one outing.
 3. When the base was last ground and which structure it received, if known.
 4. How regularly the ski has been waxed and how the base has been cared for between uses.

--- a/site/src/lib/conditionsDisplayMode.ts
+++ b/site/src/lib/conditionsDisplayMode.ts
@@ -1,0 +1,20 @@
+type ConditionsPayload = {
+  error?: unknown;
+  locations?: unknown;
+};
+
+export type ConditionsDisplayMode = 'off-season' | 'live' | 'unavailable';
+
+export function conditionsDisplayMode(
+  payload: unknown,
+  at = new Date(),
+): ConditionsDisplayMode {
+  const month = at.getMonth() + 1;
+  if (month >= 4 && month <= 10) return 'off-season';
+
+  if (typeof payload !== 'object' || payload === null) return 'unavailable';
+  const { error, locations } = payload as ConditionsPayload;
+  return !error && Array.isArray(locations) && locations.length > 0
+    ? 'live'
+    : 'unavailable';
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -97,6 +97,7 @@ const ctaStripSubhead =
     </div>
   </SectionBand>
   <CTAStrip
+    id="registration"
     heading="Come ski with us."
     subhead={ctaStripSubhead}
     cta_label={ctaStripLabel}

--- a/site/src/pages/sponsors.astro
+++ b/site/src/pages/sponsors.astro
@@ -22,6 +22,7 @@ const mailtoHref = `mailto:${page.data.contact_email}`;
   description={metaDescription(page.data.intro)}
   headline={page.data.headline}
   subhead={page.data.intro}
+  facts={[{ value: '501(c)(3) nonprofit', label: 'Status' }]}
 >
   <div class="safe-inline-6-10 mx-auto max-w-5xl px-6 md:px-10 py-16 md:py-20">
     <SponsorWall headingLevel="h2" />

--- a/site/tests/conditionsDisplayMode.test.mjs
+++ b/site/tests/conditionsDisplayMode.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import test from 'node:test';
+import { JSDOM } from 'jsdom';
 
 import { conditionsDisplayMode } from '../src/lib/conditionsDisplayMode.ts';
 
@@ -34,4 +36,88 @@ test('uses unavailable mode for an error/empty January payload', () => {
   const at = new Date('2027-01-15T12:00:00-06:00');
 
   assert.equal(conditionsDisplayMode(errorPayload, at), 'unavailable');
+});
+
+test('restores venue cells when November unavailable follows October off-season', async () => {
+  const builtHome = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
+  const assetPath = builtHome.match(
+    /<script\b[^>]*\bsrc="(\/_astro\/LiveConditions\.[^"]+\.js)"[^>]*><\/script>/i,
+  )?.[1];
+  assert.ok(assetPath, 'built home must load the Live Conditions client bundle');
+
+  const dom = new JSDOM(builtHome, { pretendToBeVisual: true });
+  const roots = [...dom.window.document.querySelectorAll('[data-live-conditions]')];
+  assert.ok(roots.length > 0, 'built home must include a Live Conditions root');
+  roots.slice(1).forEach((root) => root.remove());
+  const root = roots[0];
+
+  const original = {
+    Date: globalThis.Date,
+    document: globalThis.document,
+    fetch: globalThis.fetch,
+    setInterval: globalThis.setInterval,
+    setTimeout: globalThis.setTimeout,
+    window: globalThis.window,
+  };
+  let now = '2026-10-31T12:00:00-05:00';
+  let refresh;
+  const responses = [
+    { updated_at: now, locations: [{ id: 'wirth' }] },
+    { error: 'Conditions unavailable', locations: [] },
+  ];
+
+  class TestDate extends original.Date {
+    constructor(...args) {
+      super(...(args.length > 0 ? args : [now]));
+    }
+
+    static now() {
+      return new original.Date(now).getTime();
+    }
+  }
+
+  try {
+    globalThis.Date = TestDate;
+    globalThis.document = dom.window.document;
+    globalThis.window = dom.window;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => responses.shift(),
+    });
+    globalThis.setTimeout = () => 1;
+    globalThis.setInterval = (callback) => {
+      refresh = callback;
+      return 1;
+    };
+
+    const assetUrl = new URL(`../dist${assetPath}`, import.meta.url);
+    await import(`${assetUrl.href}?transition-regression`);
+    await new Promise((resolve) => original.setTimeout(resolve, 0));
+
+    const venueCells = [...root.querySelectorAll('[data-location]')];
+    assert.equal(venueCells.length, 4);
+    assert.ok(venueCells.every((cell) => cell.hidden && cell.style.display === 'none'));
+    assert.equal(root.querySelectorAll('[data-dryland-label]').length, 1);
+
+    now = '2026-11-01T12:00:00-05:00';
+    assert.equal(typeof refresh, 'function', 'client must register its refresh interval');
+    refresh();
+    await new Promise((resolve) => original.setTimeout(resolve, 0));
+
+    for (const cell of venueCells) {
+      assert.equal(cell.hidden, false, 'winter unavailable must unhide each venue');
+      assert.equal(cell.style.display, '', 'winter unavailable must clear inline hiding');
+      assert.equal(cell.querySelector('[data-wax]')?.textContent, 'No report');
+    }
+    assert.equal(root.querySelector('[data-dryland-label]'), null);
+    assert.equal(root.querySelector('[data-updated]')?.textContent, '● Conditions unavailable');
+  } finally {
+    globalThis.Date = original.Date;
+    globalThis.document = original.document;
+    globalThis.fetch = original.fetch;
+    globalThis.setInterval = original.setInterval;
+    globalThis.setTimeout = original.setTimeout;
+    globalThis.window = original.window;
+    dom.window.close();
+  }
 });

--- a/site/tests/conditionsDisplayMode.test.mjs
+++ b/site/tests/conditionsDisplayMode.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { conditionsDisplayMode } from '../src/lib/conditionsDisplayMode.ts';
+
+const healthyPayload = {
+  locations: [{ id: 'wirth' }],
+};
+
+const errorPayload = {
+  error: 'Conditions unavailable',
+  locations: [],
+};
+
+test('uses off-season mode for a healthy, non-empty July payload', () => {
+  const at = new Date('2026-07-19T12:00:00-05:00');
+
+  assert.equal(conditionsDisplayMode(healthyPayload, at), 'off-season');
+});
+
+test('uses off-season mode for an error/empty July payload', () => {
+  const at = new Date('2026-07-19T12:00:00-05:00');
+
+  assert.equal(conditionsDisplayMode(errorPayload, at), 'off-season');
+});
+
+test('uses live mode for a healthy, non-empty January payload', () => {
+  const at = new Date('2027-01-15T12:00:00-06:00');
+
+  assert.equal(conditionsDisplayMode(healthyPayload, at), 'live');
+});
+
+test('uses unavailable mode for an error/empty January payload', () => {
+  const at = new Date('2027-01-15T12:00:00-06:00');
+
+  assert.equal(conditionsDisplayMode(errorPayload, at), 'unavailable');
+});

--- a/site/tests/contentRefinements.test.mjs
+++ b/site/tests/contentRefinements.test.mjs
@@ -33,6 +33,7 @@ const html = {
 
 const MISSION =
   'TCSC is a 501(c)(3) nonprofit where young adult skiers train together twice a week, race if they want to, travel to Midwest ski weekends, volunteer, and organize workouts and socials beyond practice.';
+const MARKETING_ORIGIN = 'https://twincitiesskiclub.org';
 const REGISTRATION_SUBHEAD = 'Returning members Aug 28; new members Sep 3.';
 const DRY_TRI_2026 =
   'Planning for 2026 is underway. The date and registration details will be posted here when confirmed.';
@@ -84,6 +85,10 @@ function sectionById(document, id) {
   return document.slice(start, end + '</section>'.length);
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 function htmlFiles(directory) {
   return readdirSync(directory, { recursive: true, withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith('.html'))
@@ -94,7 +99,7 @@ test('wires the confirmed fall registration copy to the home CTA target', () => 
   assert.equal(yamlScalar(source.home, 'cta_coming_soon_label'), 'Fall registration dates');
   assert.equal(
     yamlScalar(source.home, 'cta_coming_soon_url'),
-    'https://tcsc.ski/#registration',
+    `${MARKETING_ORIGIN}/#registration`,
   );
   assert.equal(yamlScalar(source.home, 'mission_paragraph'), MISSION);
 
@@ -110,11 +115,24 @@ test('wires the confirmed fall registration copy to the home CTA target', () => 
   const registration = sectionById(html.home, 'registration');
   const registrationText = toText(registration);
   assert.ok(registrationText.includes(REGISTRATION_SUBHEAD));
-  assert.match(
-    registration,
-    /<a\b[^>]*href="https:\/\/tcsc\.ski\/#registration"[^>]*>Fall registration dates<\/a>/,
+  const cta = registration.match(
+    /<a\b([^>]*)>Fall registration dates<\/a>/i,
   );
-  assert.equal((html.home.match(/\bid="registration"/g) ?? []).length, 1);
+  assert.ok(cta, 'registration CTA must render as a title-bearing anchor');
+  const href = cta[1].match(/\bhref=(['"])(.*?)\1/i);
+  assert.ok(href, 'registration CTA must include an href');
+
+  const target = new URL(decodeHtml(href[2]), MARKETING_ORIGIN);
+  assert.equal(target.origin, MARKETING_ORIGIN);
+  assert.equal(target.pathname, '/');
+  assert.equal(target.hash, '#registration');
+  const targetId = target.hash.slice(1);
+  assert.equal(
+    (html.home.match(new RegExp(`\\bid=['"]${escapeRegExp(targetId)}['"]`, 'gi')) ?? [])
+      .length,
+    1,
+    'registration CTA hash must resolve to exactly one target in the built home page',
+  );
   assert.ok(toText(html.home).includes(MISSION));
 });
 

--- a/site/tests/contentRefinements.test.mjs
+++ b/site/tests/contentRefinements.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const source = {
+  home: readFileSync(new URL('../src/content/pages/home.yaml', import.meta.url), 'utf8'),
+  ctaStrip: readFileSync(new URL('../src/components/CTAStrip.astro', import.meta.url), 'utf8'),
+  homePage: readFileSync(new URL('../src/pages/index.astro', import.meta.url), 'utf8'),
+  dryTri: readFileSync(new URL('../src/content/pages/dry_tri.mdoc', import.meta.url), 'utf8'),
+  extraTraining: readFileSync(
+    new URL('../src/content/pages/extra_training.mdoc', import.meta.url),
+    'utf8',
+  ),
+  community: readFileSync(
+    new URL('../src/content/pages/community.mdoc', import.meta.url),
+    'utf8',
+  ),
+  racing: readFileSync(new URL('../src/content/pages/racing.mdoc', import.meta.url), 'utf8'),
+  sponsorsPage: readFileSync(new URL('../src/pages/sponsors.astro', import.meta.url), 'utf8'),
+};
+
+const html = {
+  home: readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8'),
+  dryTri: readFileSync(new URL('../dist/dry-tri/index.html', import.meta.url), 'utf8'),
+  extraTraining: readFileSync(
+    new URL('../dist/extra-training-fun/index.html', import.meta.url),
+    'utf8',
+  ),
+  community: readFileSync(new URL('../dist/community/index.html', import.meta.url), 'utf8'),
+  racing: readFileSync(new URL('../dist/racing/index.html', import.meta.url), 'utf8'),
+  sponsors: readFileSync(new URL('../dist/sponsors/index.html', import.meta.url), 'utf8'),
+};
+
+const MISSION =
+  'TCSC is a 501(c)(3) nonprofit where young adult skiers train together twice a week, race if they want to, travel to Midwest ski weekends, volunteer, and organize workouts and socials beyond practice.';
+const REGISTRATION_SUBHEAD = 'Returning members Aug 28; new members Sep 3.';
+const DRY_TRI_2026 =
+  'Planning for 2026 is underway. The date and registration details will be posted here when confirmed.';
+const DRY_TRI_RESULTS = 'https://my.raceresult.com/361087/results';
+
+function yamlScalar(document, key) {
+  const lines = document.split('\n');
+  const index = lines.findIndex((line) => line.startsWith(`${key}:`));
+  assert.notEqual(index, -1, `missing source field: ${key}`);
+
+  const value = lines[index].slice(key.length + 1).trim();
+  if (!['>-', '>', '|-', '|'].includes(value)) return value;
+
+  const continuation = [];
+  for (const line of lines.slice(index + 1)) {
+    if (!/^\s+\S/.test(line)) break;
+    continuation.push(line.trim());
+  }
+  return continuation.join(' ');
+}
+
+function decodeHtml(text) {
+  return text
+    .replaceAll('&#39;', "'")
+    .replaceAll('&#x27;', "'")
+    .replaceAll('&apos;', "'")
+    .replaceAll('&quot;', '"')
+    .replaceAll('&amp;', '&');
+}
+
+function toText(document) {
+  return decodeHtml(
+    document
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  )
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function sectionById(document, id) {
+  const opening = new RegExp(`<section\\b[^>]*\\bid="${id}"[^>]*>`, 'i').exec(document);
+  assert.ok(opening, `missing built section target: #${id}`);
+
+  const start = opening.index;
+  const end = document.indexOf('</section>', start + opening[0].length);
+  assert.notEqual(end, -1, `missing closing section for #${id}`);
+  return document.slice(start, end + '</section>'.length);
+}
+
+function htmlFiles(directory) {
+  return readdirSync(directory, { recursive: true, withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.html'))
+    .map((entry) => readFileSync(`${entry.parentPath}/${entry.name}`, 'utf8'));
+}
+
+test('wires the confirmed fall registration copy to the home CTA target', () => {
+  assert.equal(yamlScalar(source.home, 'cta_coming_soon_label'), 'Fall registration dates');
+  assert.equal(
+    yamlScalar(source.home, 'cta_coming_soon_url'),
+    'https://tcsc.ski/#registration',
+  );
+  assert.equal(yamlScalar(source.home, 'mission_paragraph'), MISSION);
+
+  assert.match(source.ctaStrip, /\bid\?: string;/);
+  assert.match(source.ctaStrip, /const \{ heading, subhead, cta_label, cta_url, id \} = Astro\.props;/);
+  assert.match(
+    source.ctaStrip,
+    /<section id=\{id\} class="bg-navy border-t-\[3px\] border-coral text-paper">/,
+  );
+  assert.match(source.homePage, /<CTAStrip\s+id="registration"/);
+  assert.ok(source.homePage.includes(REGISTRATION_SUBHEAD));
+
+  const registration = sectionById(html.home, 'registration');
+  const registrationText = toText(registration);
+  assert.ok(registrationText.includes(REGISTRATION_SUBHEAD));
+  assert.match(
+    registration,
+    /<a\b[^>]*href="https:\/\/tcsc\.ski\/#registration"[^>]*>Fall registration dates<\/a>/,
+  );
+  assert.equal((html.home.match(/\bid="registration"/g) ?? []).length, 1);
+  assert.ok(toText(html.home).includes(MISSION));
+});
+
+test('publishes only confirmed Dry Tri registration details while retaining 2025 history', () => {
+  assert.doesNotMatch(source.dryTri, /^register_url:/m);
+  assert.ok(source.dryTri.includes(DRY_TRI_2026));
+  assert.match(source.dryTri, new RegExp(`^results_url: ${DRY_TRI_RESULTS}$`, 'm'));
+  assert.ok(source.dryTri.includes('The first Dry Tri was held on October 25, 2025.'));
+
+  const dryTriText = toText(html.dryTri);
+  assert.ok(dryTriText.includes(DRY_TRI_2026));
+  assert.ok(dryTriText.includes('The first Dry Tri was held on October 25, 2025.'));
+  assert.ok(html.dryTri.includes(`href="${DRY_TRI_RESULTS}"`));
+  assert.doesNotMatch(html.dryTri, /href="https:\/\/tcsc\.ski\/tri\/?"/i);
+  assert.doesNotMatch(dryTriText, /Registration for the 2026 race opens/i);
+});
+
+test('identifies informal workouts as member activities in source and rendered copy', () => {
+  assert.equal(
+    yamlScalar(source.extraTraining, 'intro'),
+    'Coached practices run Tuesday and Thursday. The rest of the week, members organize their own workouts: track mornings, long rollerskis, open-water swims. Every member is welcome, and there is no signup.',
+  );
+  assert.ok(
+    source.community.includes(
+      'detail: Track mornings, long rollerskis, open-water swims. No signup; all members welcome.',
+    ),
+  );
+
+  assert.ok(toText(html.extraTraining).includes('Every member is welcome, and there is no signup.'));
+  assert.ok(
+    toText(html.community).includes(
+      'Track mornings, long rollerskis, open-water swims. No signup; all members welcome.',
+    ),
+  );
+});
+
+test('dates the Tour de Finn participation claim in source and rendered copy', () => {
+  assert.ok(source.racing.includes('notes: Two TCSC teams participated in 2026.'));
+  assert.ok(toText(html.racing).includes('Two TCSC teams participated in 2026.'));
+});
+
+test('shows nonprofit status in the sponsor masthead', () => {
+  assert.match(
+    source.sponsorsPage,
+    /facts=\{\[\{ value: '501\(c\)\(3\) nonprofit', label: 'Status' \}\]\}/,
+  );
+
+  const mainStart = html.sponsors.indexOf('<main id="main"');
+  assert.notEqual(mainStart, -1, 'missing sponsor main-content boundary');
+  const masthead = html.sponsors.slice(0, mainStart);
+  assert.ok(toText(masthead).includes('501(c)(3) nonprofit Status'));
+});
+
+test('keeps rejected generic and undated phrases out of public content', () => {
+  const publicSource = [
+    source.home,
+    source.dryTri,
+    source.extraTraining,
+    source.community,
+    source.racing,
+  ].join('\n');
+  const distDirectory = new URL('../dist/', import.meta.url);
+  const publicBuiltText = htmlFiles(distDirectory).map(toText).join('\n');
+
+  for (const rejected of [
+    /dedicated to fostering/i,
+    /promoting a healthy lifestyle/i,
+    /\bthis year\b/i,
+    /\beveryone welcome\b/i,
+  ]) {
+    assert.doesNotMatch(publicSource, rejected);
+    assert.doesNotMatch(publicBuiltText, rejected);
+  }
+});

--- a/site/tests/responsiveNav.test.mjs
+++ b/site/tests/responsiveNav.test.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const navSource = readFileSync(
+  new URL('../src/components/Nav.astro', import.meta.url),
+  'utf8',
+);
+
+test('keeps hamburger navigation visible through tablet widths', () => {
+  assert.match(
+    navSource,
+    /<nav aria-label="Primary" class="hidden lg:flex\b/,
+    'primary navigation should start at the lg breakpoint',
+  );
+  assert.match(
+    navSource,
+    /<div class="hidden lg:flex items-center gap-5">/,
+    'registration CTA should start at the lg breakpoint',
+  );
+  assert.match(
+    navSource,
+    /<button\s+class="lg:hidden\b/,
+    'menu button should remain visible below the lg breakpoint',
+  );
+  assert.doesNotMatch(navSource, /\bhidden md:flex\b|\bmd:hidden\b/);
+});

--- a/site/tests/waxRoomEntry.test.mjs
+++ b/site/tests/waxRoomEntry.test.mjs
@@ -1,39 +1,24 @@
 import assert from 'node:assert/strict';
 import { existsSync, readFileSync } from 'node:fs';
 import test from 'node:test';
+import { JSDOM } from 'jsdom';
 
 const title = 'Stone Grind or Hotbox? When Skis Need a Second Wind';
 const route = '/wax-room/stone-grind-or-hotbox/';
 const linkTarget = route.slice(0, -1);
+const headings = [
+  'What a stone grind changes',
+  'What a hotbox changes',
+  'Five useful things to tell the shop',
+  'The short version',
+];
 const sourceUrl = new URL(
   '../src/content/wax_entries/stone-grind-or-hotbox.mdoc',
   import.meta.url,
 );
 const detailUrl = new URL('../dist/wax-room/stone-grind-or-hotbox/index.html', import.meta.url);
 
-const decodeHtml = (text) =>
-  text
-    .replaceAll('&#39;', "'")
-    .replaceAll('&#x27;', "'")
-    .replaceAll('&apos;', "'")
-    .replaceAll('&quot;', '"')
-    .replaceAll('&amp;', '&');
-
-const toText = (html) =>
-  decodeHtml(
-    html
-      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
-      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
-      .replace(/<[^>]+>/g, ' '),
-  )
-    .replace(/\s+/g, ' ')
-    .trim();
-
-const bodyHtml = (html) => {
-  const body = html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
-  assert.ok(body, 'built page must include a body element');
-  return body[1];
-};
+const toText = (node) => node.textContent.replace(/\s+/g, ' ').trim();
 
 test('publishes the contingency Wax Room field guide', () => {
   assert.equal(existsSync(sourceUrl), true, 'Wax Room entry source must exist');
@@ -43,42 +28,62 @@ test('publishes the contingency Wax Room field guide', () => {
   const homeHtml = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
   const indexHtml = readFileSync(new URL('../dist/wax-room/index.html', import.meta.url), 'utf8');
   const detailHtml = readFileSync(detailUrl, 'utf8');
-  const homeBody = bodyHtml(homeHtml);
-  const indexBody = bodyHtml(indexHtml);
-  const detailBody = bodyHtml(detailHtml);
+  const homeDocument = new JSDOM(homeHtml).window.document;
+  const indexDocument = new JSDOM(indexHtml).window.document;
+  const detailDocument = new JSDOM(detailHtml).window.document;
 
-  for (const [surface, body] of [
-    ['home page', homeBody],
-    ['Wax Room index', indexBody],
-    ['Wax Room detail', detailBody],
+  for (const [surface, document] of [
+    ['home page', homeDocument],
+    ['Wax Room index', indexDocument],
   ]) {
-    assert.ok(toText(body).includes(title), `${surface} must visibly include the title`);
-  }
-
-  const detailH1 = detailBody.match(/<h1\b[^>]*>([\s\S]*?)<\/h1>/i);
-  assert.ok(detailH1, 'Wax Room detail must include an h1');
-  assert.equal(toText(detailH1[1]), title, 'Wax Room detail h1 must be the article title');
-
-  for (const [surface, html] of [
-    ['home page', homeHtml],
-    ['Wax Room index', indexHtml],
-  ]) {
-    assert.match(
-      html,
-      new RegExp(`href=["']${linkTarget}["']`),
-      `${surface} must link to ${route}`,
+    const titleLinks = [...document.querySelectorAll('a')].filter((anchor) =>
+      toText(anchor).includes(title),
+    );
+    assert.equal(titleLinks.length, 1, `${surface} must include one title-bearing anchor`);
+    assert.equal(
+      titleLinks[0].getAttribute('href'),
+      linkTarget,
+      `${surface} title must link to ${route}`,
     );
   }
+
+  const article = detailDocument.querySelector('main > article');
+  assert.ok(article, 'Wax Room detail must render the entry as an article');
+  const h1s = [...article.querySelectorAll('h1')];
+  assert.equal(h1s.length, 1, 'rendered entry article must include exactly one h1');
+  assert.equal(toText(h1s[0]), title, 'Wax Room detail h1 must be the article title');
+  assert.deepEqual([...article.querySelectorAll('h2')].map(toText), headings);
+  assert.equal(
+    article.querySelectorAll('ol > li').length,
+    5,
+    'rendered checklist must have five items',
+  );
+
+  const articleText = toText(article);
+  for (const fact of [
+    'Eleven pairs joined a coordinated Finn Sisu service order.',
+    "Finn Sisu's universal grind for a Midwest/manmade mix.",
+    'A stone grind permanently cuts structure into the ski base.',
+    'A hotbox uses controlled warmth to condition the base with wax over time.',
+    'None of these labels is a slow-to-fast ranking.',
+    'Choose both only when both jobs make sense for that ski.',
+  ]) {
+    assert.ok(articleText.includes(fact), `rendered article must include: ${fact}`);
+  }
+  assert.equal(
+    [...article.querySelectorAll('*')].some((element) =>
+      /^By\s+.+\s+·\s+(?:coach|member|board)$/i.test(toText(element)),
+    ),
+    false,
+    'entry article must not render a byline',
+  );
+  assert.equal(article.querySelector('aside'), null, 'entry article must not render conditions');
+  assert.equal(article.querySelector('img'), null, 'entry article must not render a photo');
 
   assert.match(source, /^date: 2026-07-19$/m);
   assert.doesNotMatch(source, /^(?:author_name|photo|conditions_snapshot):/m);
 
-  for (const heading of [
-    'What a stone grind changes',
-    'What a hotbox changes',
-    'Five useful things to tell the shop',
-    'The short version',
-  ]) {
+  for (const heading of headings) {
     assert.match(source, new RegExp(`^## ${heading}$`, 'm'), `missing heading: ${heading}`);
   }
 

--- a/site/tests/waxRoomEntry.test.mjs
+++ b/site/tests/waxRoomEntry.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const title = 'Stone Grind or Hotbox? When Skis Need a Second Wind';
+const route = '/wax-room/stone-grind-or-hotbox/';
+const linkTarget = route.slice(0, -1);
+const sourceUrl = new URL(
+  '../src/content/wax_entries/stone-grind-or-hotbox.mdoc',
+  import.meta.url,
+);
+const detailUrl = new URL('../dist/wax-room/stone-grind-or-hotbox/index.html', import.meta.url);
+
+const decodeHtml = (text) =>
+  text
+    .replaceAll('&#39;', "'")
+    .replaceAll('&#x27;', "'")
+    .replaceAll('&apos;', "'")
+    .replaceAll('&quot;', '"')
+    .replaceAll('&amp;', '&');
+
+const toText = (html) =>
+  decodeHtml(
+    html
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+      .replace(/<[^>]+>/g, ' '),
+  )
+    .replace(/\s+/g, ' ')
+    .trim();
+
+test('publishes the contingency Wax Room field guide', () => {
+  assert.equal(existsSync(sourceUrl), true, 'Wax Room entry source must exist');
+  assert.equal(existsSync(detailUrl), true, `Astro must generate ${route}`);
+
+  const source = readFileSync(sourceUrl, 'utf8');
+  const homeHtml = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
+  const indexHtml = readFileSync(new URL('../dist/wax-room/index.html', import.meta.url), 'utf8');
+  const detailHtml = readFileSync(detailUrl, 'utf8');
+
+  for (const [surface, html] of [
+    ['home page', homeHtml],
+    ['Wax Room index', indexHtml],
+    ['Wax Room detail', detailHtml],
+  ]) {
+    assert.ok(toText(html).includes(title), `${surface} must include the article title`);
+  }
+
+  for (const [surface, html] of [
+    ['home page', homeHtml],
+    ['Wax Room index', indexHtml],
+  ]) {
+    assert.match(
+      html,
+      new RegExp(`href=["']${linkTarget}["']`),
+      `${surface} must link to ${route}`,
+    );
+  }
+
+  assert.match(source, /^date: 2026-07-19$/m);
+  assert.doesNotMatch(source, /^(?:author_name|photo|conditions_snapshot):/m);
+
+  for (const heading of [
+    'What a stone grind changes',
+    'What a hotbox changes',
+    'Five useful things to tell the shop',
+    'The short version',
+  ]) {
+    assert.match(source, new RegExp(`^## ${heading}$`, 'm'), `missing heading: ${heading}`);
+  }
+
+  assert.doesNotMatch(source, /\$\s*\d/, 'article must not include a dollar price');
+  assert.doesNotMatch(
+    source,
+    /\b(?:discount(?:ed|s)?|percent off|save \d+%?|\d+% off)\b/i,
+    'article must not include a discount claim',
+  );
+  assert.doesNotMatch(source, /—/, 'article must not include an em dash');
+  assert.doesNotMatch(source, /!/, 'article must not include an exclamation point');
+});

--- a/site/tests/waxRoomEntry.test.mjs
+++ b/site/tests/waxRoomEntry.test.mjs
@@ -29,6 +29,12 @@ const toText = (html) =>
     .replace(/\s+/g, ' ')
     .trim();
 
+const bodyHtml = (html) => {
+  const body = html.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
+  assert.ok(body, 'built page must include a body element');
+  return body[1];
+};
+
 test('publishes the contingency Wax Room field guide', () => {
   assert.equal(existsSync(sourceUrl), true, 'Wax Room entry source must exist');
   assert.equal(existsSync(detailUrl), true, `Astro must generate ${route}`);
@@ -37,14 +43,21 @@ test('publishes the contingency Wax Room field guide', () => {
   const homeHtml = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
   const indexHtml = readFileSync(new URL('../dist/wax-room/index.html', import.meta.url), 'utf8');
   const detailHtml = readFileSync(detailUrl, 'utf8');
+  const homeBody = bodyHtml(homeHtml);
+  const indexBody = bodyHtml(indexHtml);
+  const detailBody = bodyHtml(detailHtml);
 
-  for (const [surface, html] of [
-    ['home page', homeHtml],
-    ['Wax Room index', indexHtml],
-    ['Wax Room detail', detailHtml],
+  for (const [surface, body] of [
+    ['home page', homeBody],
+    ['Wax Room index', indexBody],
+    ['Wax Room detail', detailBody],
   ]) {
-    assert.ok(toText(html).includes(title), `${surface} must include the article title`);
+    assert.ok(toText(body).includes(title), `${surface} must visibly include the title`);
   }
+
+  const detailH1 = detailBody.match(/<h1\b[^>]*>([\s\S]*?)<\/h1>/i);
+  assert.ok(detailH1, 'Wax Room detail must include an h1');
+  assert.equal(toText(detailH1[1]), title, 'Wax Room detail h1 must be the article title');
 
   for (const [surface, html] of [
     ['home page', homeHtml],
@@ -68,6 +81,16 @@ test('publishes the contingency Wax Room field guide', () => {
   ]) {
     assert.match(source, new RegExp(`^## ${heading}$`, 'm'), `missing heading: ${heading}`);
   }
+
+  assert.match(source, /Shop labels vary\./);
+  assert.match(source, /Fine, medium, and coarse[^.]*structure grades/i);
+  assert.match(source, /Universal[^.]*(?:broader-use|broader use)[^.]*(?:pattern|menu label)/i);
+  assert.match(source, /None of these labels is a slow-to-fast ranking\./);
+
+  const checklistItems = source.match(/^\d+\. .+$/gm) ?? [];
+  assert.equal(checklistItems.length, 5, 'shop checklist must contain exactly five items');
+  assert.match(checklistItems.join('\n'), /classic or skate/i);
+  assert.match(checklistItems.join('\n'), /technique affects structure selection/i);
 
   assert.doesNotMatch(source, /\$\s*\d/, 'article must not include a dollar price');
   assert.doesNotMatch(


### PR DESCRIPTION
## Summary
- make the conditions strip season-aware and remove tablet-width header overflow
- publish the first Wax Room maintenance guide
- correct registration, Dry Tri, membership, racing, mission, and sponsor copy
- add focused regression coverage for the refined surfaces

## Verification
- 13 refinement tests passed
- 24 sponsor tests passed
- 74 conditions and Wix scrape tests passed
- Astro check: 0 errors, warnings, or hints
- 77 rendered route and viewport audits passed
- independent whole-branch review: ready to merge

## Known notice
- Astro still reports the pre-existing empty trips collection during builds