### PR TITLE
Show wax recommendations year round

### DIFF
--- a/docs/superpowers/plans/2026-07-19-year-round-wax-recommendations.md
+++ b/docs/superpowers/plans/2026-07-19-year-round-wax-recommendations.md
@@ -25,7 +25,7 @@
 
 - Modify `site/src/lib/conditionsDisplayMode.ts`: make payload health take precedence over the seasonal failure choice.
 - Modify `site/src/components/LiveConditions.client.ts`: correct the `renderQuiet()` comment so it documents the new failure-only off-season path. Do not alter rendering logic.
-- Modify `site/tests/conditionsDisplayMode.test.mjs`: update the July unit contract and add one healthy-summer rendered-DOM regression.
+- Modify `site/tests/conditionsDisplayMode.test.mjs`: update the July unit contract and add one healthy-summer live-to-failure rendered-DOM regression.
 - Leave `site/src/components/LiveConditions.astro`, `site/package.json`, and every backend file unchanged.
 
 ### Task 1: Render Healthy Conditions Year Round
@@ -53,10 +53,10 @@ test('uses live mode for a healthy, non-empty July payload', () => {
 });
 ```
 
-Then insert this test immediately before `restores venue cells when November unavailable follows October off-season`:
+Then insert this sequential live-to-failure regression immediately before `restores venue cells when November unavailable follows October off-season`:
 
 ```js
-test('renders real temperatures and wax recommendations from a healthy July payload', async () => {
+test('renders healthy July data then clears it for a failed July refresh', async () => {
   const builtHome = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
   const assetPath = builtHome.match(
     /<script\b[^>]*\bsrc="(\/_astro\/LiveConditions\.[^"]+\.js)"[^>]*><\/script>/i,
@@ -78,6 +78,7 @@ test('renders real temperatures and wax recommendations from a healthy July payl
     window: globalThis.window,
   };
   const now = '2026-07-19T15:14:56-05:00';
+  let refresh;
   const payload = {
     updated_at: now,
     locations: [
@@ -85,13 +86,13 @@ test('renders real temperatures and wax recommendations from a healthy July payl
         id: 'wirth',
         name: 'Theo',
         temp_f: 88,
-        wind_chill_f: 88,
+        wind_chill_f: 84,
         snow_conditions: null,
         wax_band: 'red',
         wax_label: 'Red wax · klister conditions',
-        source_url: null,
-        report_date: null,
-        groomed_for: null,
+        source_url: 'https://www.skinnyski.com/trails/report.asp?id=123',
+        report_date: '2026-07-18',
+        groomed_for: 'skate',
       },
     ],
     birkie: {
@@ -100,6 +101,7 @@ test('renders real temperatures and wax recommendations from a healthy July payl
       detail: 'No fever yet. Birkie 2027 talk starts in November.',
     },
   };
+  const responses = [payload, errorPayload];
 
   class TestDate extends original.Date {
     constructor(...args) {
@@ -117,10 +119,13 @@ test('renders real temperatures and wax recommendations from a healthy July payl
     globalThis.window = dom.window;
     globalThis.fetch = async () => ({
       ok: true,
-      json: async () => payload,
+      json: async () => responses.shift(),
     });
     globalThis.setTimeout = () => 1;
-    globalThis.setInterval = () => 1;
+    globalThis.setInterval = (callback) => {
+      refresh = callback;
+      return 1;
+    };
 
     const assetUrl = new URL(`../dist${assetPath}`, import.meta.url);
     await import(`${assetUrl.href}?healthy-summer-regression`);
@@ -131,9 +136,21 @@ test('renders real temperatures and wax recommendations from a healthy July payl
     assert.equal(wirth.hidden, false);
     assert.equal(wirth.style.display, '');
     assert.equal(wirth.querySelector('[data-temp]')?.textContent, '88°F');
+    assert.equal(wirth.querySelector('[data-feels]')?.textContent, 'feels 84°');
     assert.equal(
       wirth.querySelector('[data-wax]')?.textContent,
       'Red wax · klister conditions',
+    );
+
+    const sourceLink = wirth.querySelector('a[data-source-link]');
+    assert.ok(sourceLink, 'healthy payload must render its trail report link');
+    assert.equal(
+      sourceLink.getAttribute('href'),
+      'https://www.skinnyski.com/trails/report.asp?id=123',
+    );
+    assert.equal(
+      wirth.querySelector('[data-groomed]')?.textContent,
+      'Groomed skate · Jul 18',
     );
 
     const chip = wirth.querySelector('[data-wax-chip]');
@@ -143,6 +160,30 @@ test('renders real temperatures and wax recommendations from a healthy July payl
     assert.equal(root.querySelector('[data-dryland-label]'), null);
     assert.match(root.querySelector('[data-updated]')?.textContent ?? '', /^● Live · updated /);
     assert.equal(root.querySelector('[data-birkie-word]')?.textContent, '98.6°');
+    assert.equal(root.dataset.updatedAt, now);
+
+    assert.equal(typeof refresh, 'function', 'client must register its refresh interval');
+    refresh();
+    await new Promise((resolve) => original.setTimeout(resolve, 0));
+
+    const venueCells = [...root.querySelectorAll('[data-location]')];
+    assert.equal(venueCells.length, 4);
+    for (const cell of venueCells) {
+      assert.equal(cell.hidden, true, 'summer failure must hide each venue');
+      assert.equal(cell.style.display, 'none', 'summer failure must hide each venue inline');
+      assert.equal(cell.querySelector('[data-temp]')?.textContent, '');
+      assert.equal(cell.querySelector('[data-feels]')?.textContent, '');
+      assert.equal(cell.querySelector('[data-wax]')?.textContent, 'Dryland season');
+      assert.equal(cell.querySelector('[data-wax-chip]')?.hidden, true);
+      assert.equal(cell.querySelector('[data-source-link]'), null);
+      assert.equal(cell.querySelector('[data-groomed]'), null);
+    }
+    assert.equal(root.querySelectorAll('[data-dryland-label]').length, 1);
+    assert.equal(root.dataset.updatedAt, undefined);
+    assert.equal(
+      root.querySelector('[data-updated]')?.textContent,
+      '● Trail reports come back with the snow',
+    );
   } finally {
     globalThis.Date = original.Date;
     globalThis.document = original.document;
@@ -218,7 +259,7 @@ npm run build -- --force
 node --test tests/conditionsDisplayMode.test.mjs
 ```
 
-Expected: 6 tests pass, 0 fail. Confirm that the healthy and failed July cases now select different modes and that the October-to-November regression remains green.
+Expected: 6 tests pass, 0 fail. Confirm that the healthy and failed July cases now select different modes, the healthy-July-to-failed-July refresh clears every live artifact into the off-season fallback, and the October-to-November regression remains green.
 
 - [ ] **Step 5: Run the full automated regression suite**
 
@@ -294,6 +335,16 @@ with sync_playwright() as playwright:
         page = context.new_page()
         page.add_init_script(
             """
+            const NativeDate = window.Date;
+            const frozenNow = "2026-07-19T15:14:56-05:00";
+            window.Date = class TestDate extends NativeDate {
+              constructor(...args) {
+                super(...(args.length > 0 ? args : [frozenNow]));
+              }
+              static now() {
+                return new NativeDate(frozenNow).getTime();
+              }
+            };
             window.__tcscConditionsCls = 0;
             window.__tcscLayoutObserver = new PerformanceObserver((list) => {
               for (const entry of list.getEntries()) {
@@ -358,6 +409,7 @@ PY
 Expected:
 
 - Home and About return 200 at 390px and 1440px.
+- The browser clock is frozen to the July fixture before the conditions client initializes.
 - Theo shows `88°F` and `Red wax · klister conditions` on both variants.
 - Desktop shows all four venues and Birkie Fever; mobile shows Theo only.
 - No dryland label or summer-specific copy appears with healthy data.

--- a/docs/superpowers/plans/2026-07-19-year-round-wax-recommendations.md
+++ b/docs/superpowers/plans/2026-07-19-year-round-wax-recommendations.md
@@ -1,0 +1,387 @@
+# Year-Round Wax Recommendations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render real venue temperatures and the existing winter wax recommendations year round whenever the conditions API returns a healthy payload.
+
+**Architecture:** Keep the API, Astro markup, visual system, and live renderer unchanged. Make `conditionsDisplayMode()` payload-first so healthy data always selects `live`, then use the browser month only to choose between the existing `off-season` and `unavailable` failure states. Protect the behavior with both a unit contract and a rendered-DOM regression.
+
+**Tech Stack:** Astro 7, TypeScript, Node test runner, JSDOM 29, Python Playwright, Tailwind CSS 4, Flask/Pytest regression suite
+
+## Global Constraints
+
+- A healthy payload means no top-level `error` and a non-empty `locations` array.
+- A healthy payload must select `live` in every month.
+- An unhealthy April-through-October payload must select `off-season`.
+- An unhealthy November-through-March payload must select `unavailable`.
+- Use the existing temperature, wax band, wax label, timestamp, venue, grooming, and Birkie data without transformation.
+- Add no summer-specific copy, visual treatment, badge, color, icon, animation, or interaction.
+- Keep `Trail report`, the existing live updated-time stamp, all wax labels, wax thresholds, responsive visibility, Birkie Fever, audio, accessibility, refresh behavior, and failure copy unchanged.
+- Make no backend, API schema, content schema, package, or global design-token change.
+
+---
+
+## File Structure
+
+- Modify `site/src/lib/conditionsDisplayMode.ts`: make payload health take precedence over the seasonal failure choice.
+- Modify `site/src/components/LiveConditions.client.ts`: correct the `renderQuiet()` comment so it documents the new failure-only off-season path. Do not alter rendering logic.
+- Modify `site/tests/conditionsDisplayMode.test.mjs`: update the July unit contract and add one healthy-summer rendered-DOM regression.
+- Leave `site/src/components/LiveConditions.astro`, `site/package.json`, and every backend file unchanged.
+
+### Task 1: Render Healthy Conditions Year Round
+
+**Files:**
+
+- Modify: `site/src/lib/conditionsDisplayMode.ts:8-20`
+- Modify: `site/src/components/LiveConditions.client.ts:94-99`
+- Test: `site/tests/conditionsDisplayMode.test.mjs:17-123`
+
+**Interfaces:**
+
+- Consumes: `conditionsDisplayMode(payload: unknown, at?: Date): ConditionsDisplayMode`, the existing `/api/conditions` payload, and the existing `LiveConditions` DOM hooks.
+- Produces: the unchanged `ConditionsDisplayMode` union (`'off-season' | 'live' | 'unavailable'`) with payload-first selection semantics.
+
+- [ ] **Step 1: Write the failing selector and rendered-DOM tests**
+
+In `site/tests/conditionsDisplayMode.test.mjs`, replace the current healthy-July test with:
+
+```js
+test('uses live mode for a healthy, non-empty July payload', () => {
+  const at = new Date('2026-07-19T12:00:00-05:00');
+
+  assert.equal(conditionsDisplayMode(healthyPayload, at), 'live');
+});
+```
+
+Then insert this test immediately before `restores venue cells when November unavailable follows October off-season`:
+
+```js
+test('renders real temperatures and wax recommendations from a healthy July payload', async () => {
+  const builtHome = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
+  const assetPath = builtHome.match(
+    /<script\b[^>]*\bsrc="(\/_astro\/LiveConditions\.[^"]+\.js)"[^>]*><\/script>/i,
+  )?.[1];
+  assert.ok(assetPath, 'built home must load the Live Conditions client bundle');
+
+  const dom = new JSDOM(builtHome, { pretendToBeVisual: true });
+  const roots = [...dom.window.document.querySelectorAll('[data-live-conditions]')];
+  assert.ok(roots.length > 0, 'built home must include a Live Conditions root');
+  roots.slice(1).forEach((root) => root.remove());
+  const root = roots[0];
+
+  const original = {
+    Date: globalThis.Date,
+    document: globalThis.document,
+    fetch: globalThis.fetch,
+    setInterval: globalThis.setInterval,
+    setTimeout: globalThis.setTimeout,
+    window: globalThis.window,
+  };
+  const now = '2026-07-19T15:14:56-05:00';
+  const payload = {
+    updated_at: now,
+    locations: [
+      {
+        id: 'wirth',
+        name: 'Theo',
+        temp_f: 88,
+        wind_chill_f: 88,
+        snow_conditions: null,
+        wax_band: 'red',
+        wax_label: 'Red wax · klister conditions',
+        source_url: null,
+        report_date: null,
+        groomed_for: null,
+      },
+    ],
+    birkie: {
+      status: 'early',
+      word: '98.6°',
+      detail: 'No fever yet. Birkie 2027 talk starts in November.',
+    },
+  };
+
+  class TestDate extends original.Date {
+    constructor(...args) {
+      super(...(args.length > 0 ? args : [now]));
+    }
+
+    static now() {
+      return new original.Date(now).getTime();
+    }
+  }
+
+  try {
+    globalThis.Date = TestDate;
+    globalThis.document = dom.window.document;
+    globalThis.window = dom.window;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => payload,
+    });
+    globalThis.setTimeout = () => 1;
+    globalThis.setInterval = () => 1;
+
+    const assetUrl = new URL(`../dist${assetPath}`, import.meta.url);
+    await import(`${assetUrl.href}?healthy-summer-regression`);
+    await new Promise((resolve) => original.setTimeout(resolve, 0));
+
+    const wirth = root.querySelector('[data-location="wirth"]');
+    assert.ok(wirth, 'home strip must include the Theo venue cell');
+    assert.equal(wirth.hidden, false);
+    assert.equal(wirth.style.display, '');
+    assert.equal(wirth.querySelector('[data-temp]')?.textContent, '88°F');
+    assert.equal(
+      wirth.querySelector('[data-wax]')?.textContent,
+      'Red wax · klister conditions',
+    );
+
+    const chip = wirth.querySelector('[data-wax-chip]');
+    assert.ok(chip, 'prominent venue cell must include its wax chip');
+    assert.equal(chip.hidden, false);
+    assert.equal(chip.dataset.band, 'red');
+    assert.equal(root.querySelector('[data-dryland-label]'), null);
+    assert.match(root.querySelector('[data-updated]')?.textContent ?? '', /^● Live · updated /);
+    assert.equal(root.querySelector('[data-birkie-word]')?.textContent, '98.6°');
+  } finally {
+    globalThis.Date = original.Date;
+    globalThis.document = original.document;
+    globalThis.fetch = original.fetch;
+    globalThis.setInterval = original.setInterval;
+    globalThis.setTimeout = original.setTimeout;
+    globalThis.window = original.window;
+    dom.window.close();
+  }
+});
+```
+
+In the existing October-to-November transition regression, replace its `responses` fixture with two unavailable payloads so the test continues to exercise a failed October response followed by a failed November response:
+
+```js
+  const responses = [
+    { error: 'Conditions unavailable', locations: [] },
+    { error: 'Conditions unavailable', locations: [] },
+  ];
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+cd site
+npm run build -- --force
+node --test tests/conditionsDisplayMode.test.mjs
+```
+
+Expected: the healthy-July unit test fails because the selector returns `off-season`, and the rendered-DOM test fails because the Theo cell is hidden and does not contain `88°F`. The existing failed-July and winter cases must still pass.
+
+- [ ] **Step 3: Implement payload-first display-mode selection**
+
+Replace `conditionsDisplayMode()` in `site/src/lib/conditionsDisplayMode.ts` with:
+
+```ts
+export function conditionsDisplayMode(
+  payload: unknown,
+  at = new Date(),
+): ConditionsDisplayMode {
+  if (typeof payload === 'object' && payload !== null) {
+    const { error, locations } = payload as ConditionsPayload;
+    if (!error && Array.isArray(locations) && locations.length > 0) {
+      return 'live';
+    }
+  }
+
+  const month = at.getMonth() + 1;
+  return month >= 4 && month <= 10 ? 'off-season' : 'unavailable';
+}
+```
+
+In `site/src/components/LiveConditions.client.ts`, replace the opening `renderQuiet()` comment with:
+
+```ts
+  // Unavailable conditions say it once in the stamp; cells go quiet ("No
+  // report") instead of repeating the error four times. Off-season
+  // (April-October) is a failure-only fallback; healthy payloads render the
+  // same live temperature and wax instrument year round.
+```
+
+Do not alter `renderInto()`, `renderQuiet()`, the Astro markup, or any copy.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+cd site
+npm run build -- --force
+node --test tests/conditionsDisplayMode.test.mjs
+```
+
+Expected: 6 tests pass, 0 fail. Confirm that the healthy and failed July cases now select different modes and that the October-to-November regression remains green.
+
+- [ ] **Step 5: Run the full automated regression suite**
+
+Run:
+
+```bash
+cd site
+npm run test:refinement
+npm run test:sponsors
+npx astro check
+cd ..
+/Users/rob/env/tcsc-trips/env/bin/pytest tests/conditions tests/wix_scrape -q
+```
+
+Expected:
+
+- 14 refinement tests pass.
+- 24 sponsor tests pass.
+- Astro reports 0 errors, 0 warnings, and 0 hints.
+- 74 backend tests pass.
+- The existing empty `trips` and `wax_entries` collection notices may appear during builds; they are unrelated to this feature.
+
+- [ ] **Step 6: Verify both responsive variants with a healthy summer payload**
+
+Start the built site in one terminal:
+
+```bash
+cd site
+npx astro preview --host 127.0.0.1 --port 4327
+```
+
+In another terminal, run:
+
+```bash
+/Users/rob/env/tcsc-trips/env/bin/python - <<'PY'
+import json
+
+from playwright.sync_api import expect, sync_playwright
+
+payload = {
+    "updated_at": "2026-07-19T15:14:56-05:00",
+    "locations": [
+        {
+            "id": venue_id,
+            "name": name,
+            "temp_f": temp,
+            "wind_chill_f": temp,
+            "snow_conditions": None,
+            "wax_band": "red",
+            "wax_label": "Red wax · klister conditions",
+            "source_url": None,
+            "report_date": None,
+            "groomed_for": None,
+        }
+        for venue_id, name, temp in (
+            ("wirth", "Theo", 88),
+            ("elm", "Elm", 88),
+            ("hyland", "Hyland", 87),
+            ("telemark", "Telemark", 82),
+        )
+    ],
+    "birkie": {
+        "status": "early",
+        "word": "98.6°",
+        "detail": "No fever yet. Birkie 2027 talk starts in November.",
+    },
+}
+
+with sync_playwright() as playwright:
+    browser = playwright.chromium.launch(headless=True)
+    for width in (390, 1440):
+        context = browser.new_context(viewport={"width": width, "height": 900})
+        page = context.new_page()
+        page.add_init_script(
+            """
+            window.__tcscConditionsCls = 0;
+            window.__tcscLayoutObserver = new PerformanceObserver((list) => {
+              for (const entry of list.getEntries()) {
+                const root = document.querySelector('[data-live-conditions]');
+                const touchesConditions = root && entry.sources?.some(
+                  (source) => source.node && root.contains(source.node)
+                );
+                if (!entry.hadRecentInput && touchesConditions) {
+                  window.__tcscConditionsCls += entry.value;
+                }
+              }
+            });
+            window.__tcscLayoutObserver.observe({ type: 'layout-shift', buffered: true });
+            """
+        )
+        page_errors = []
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+        page.route(
+            "**/api/conditions",
+            lambda route: route.fulfill(
+                status=200,
+                content_type="application/json",
+                headers={"access-control-allow-origin": "*"},
+                body=json.dumps(payload),
+            ),
+        )
+
+        for route_path, surface in (("/", "home"), ("/about", "about")):
+            response = page.goto(f"http://127.0.0.1:4327{route_path}", wait_until="networkidle")
+            assert response is not None and response.status == 200
+            root = page.locator("[data-live-conditions]")
+            expect(root.locator('[data-location="wirth"] [data-temp]')).to_have_text("88°F")
+            expect(root.locator('[data-location="wirth"] [data-wax]')).to_have_text(
+                "Red wax · klister conditions"
+            )
+            assert root.locator("[data-dryland-label]").count() == 0
+            assert "Summer" not in root.inner_text()
+            assert page.evaluate(
+                "document.documentElement.scrollWidth - document.documentElement.clientWidth"
+            ) == 0
+            assert page.evaluate("window.__tcscConditionsCls") < 0.01
+
+            if width == 1440:
+                for venue_id in ("wirth", "elm", "hyland", "telemark"):
+                    assert root.locator(f'[data-location="{venue_id}"]').is_visible()
+                expect(root.locator("[data-birkie-word]")).to_have_text("98.6°")
+            else:
+                assert root.locator('[data-location="wirth"]').is_visible()
+                assert not root.locator('[data-location="elm"]').is_visible()
+
+            page.screenshot(
+                path=f"/tmp/year-round-wax-{surface}-{width}.png",
+                full_page=True,
+            )
+
+        assert page_errors == []
+        context.close()
+    browser.close()
+PY
+```
+
+Expected:
+
+- Home and About return 200 at 390px and 1440px.
+- Theo shows `88°F` and `Red wax · klister conditions` on both variants.
+- Desktop shows all four venues and Birkie Fever; mobile shows Theo only.
+- No dryland label or summer-specific copy appears with healthy data.
+- Every checked page has zero horizontal overflow, cumulative layout shift below 0.01, and no page errors.
+- Inspect the four screenshots and confirm the existing hierarchy, spacing, colors, and visual seriousness are unchanged.
+
+- [ ] **Step 7: Review scope and commit the implementation**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+git diff -- site/src/lib/conditionsDisplayMode.ts site/src/components/LiveConditions.client.ts site/tests/conditionsDisplayMode.test.mjs
+```
+
+Expected: exactly the selector, explanatory comment, and conditions test file are modified. No Astro, backend, package, content, or token file appears.
+
+Commit:
+
+```bash
+git add -- \
+  site/src/lib/conditionsDisplayMode.ts \
+  site/src/components/LiveConditions.client.ts \
+  site/tests/conditionsDisplayMode.test.mjs
+git commit -m "fix(site): show wax recommendations year round"
+```

--- a/docs/superpowers/specs/2026-07-19-year-round-wax-recommendations-design.md
+++ b/docs/superpowers/specs/2026-07-19-year-round-wax-recommendations-design.md
@@ -1,0 +1,133 @@
+# Year-Round Wax Recommendations Design
+
+**Date:** 2026-07-19
+**Status:** Approved direction, awaiting written-spec review
+
+## Context
+
+TCSC's Live Conditions strip receives current temperatures and mechanically derives the winter wax recommendation for each venue. The API already produces those values year round. In summer, that can yield an entirely correct result such as an 88°F reading paired with `Red wax · klister conditions`.
+
+Website 2.1 added a client-side calendar gate that suppresses every healthy April-through-October payload. The strip instead collapses to `Dryland season`, removes the venue readings, and says trail reports will return with the snow. That behavior hides useful live data and removes the dry, ski-nerdy humor that comes from presenting the recommendation literally.
+
+## Decision
+
+Use the same live conditions instrument in every month when the API returns a healthy payload. Present the real current temperature and the existing winter wax recommendation without explaining, decorating, or amplifying the joke.
+
+The calendar remains relevant only when live data is unavailable:
+
+- April through October failure: show the existing `Dryland season` fallback.
+- November through March failure: show the existing `Conditions unavailable` fallback.
+
+## Goals
+
+- Restore actual venue temperatures and wax recommendations year round.
+- Keep the feature visually serious, technically credible, and unmistakably part of the existing TCSC brand.
+- Let the literal recommendation carry the humor by itself.
+- Preserve the existing winter experience, responsive behavior, Birkie Fever interaction, accessibility, refresh policy, and failure handling.
+- Make healthy-data precedence explicit and regression-tested.
+
+## Non-Goals
+
+- No new summer-specific copy, badges, colors, illustrations, icons, or animation.
+- No explanation that the wax recommendation is theoretical.
+- No separate summer component or expanded summer layout.
+- No backend or API schema changes.
+- No new weather fields, future forecast data, or snow-depth simulation.
+- No changes to wax temperature thresholds or labels.
+- No changes to Birkie Fever values, copy, audio, or interaction.
+
+## Experience Contract
+
+### Healthy payload, any month
+
+The prominent home-page strip keeps its current presentation:
+
+- `Trail report` label
+- factual `Live · updated [time]` stamp
+- Theo, Elm, Hyland, and Telemark venue cells on desktop
+- Theo on mobile
+- real temperature and materially different feels-like temperature
+- the existing wax-color chip and exact API wax label
+- trail report links and grooming details when the API supplies them
+- Birkie Fever on desktop, including the user-triggered song
+
+The compact inner-page strip likewise keeps its current presentation:
+
+- all four venue lines and Birkie Fever on desktop
+- Theo on mobile
+- current temperature and exact wax recommendation
+
+Summer does not receive a different visual treatment. The professional ledger and live timestamp make the output feel intentional. The unexpected recommendation supplies the personality.
+
+### Loading and no JavaScript
+
+Keep the current server-rendered venue names, placeholders, loading stamp, first-fill transition, and 1.2-second visibility backstop. This change does not introduce a new loading state.
+
+### Unavailable payload
+
+Keep the two existing quiet fallbacks:
+
+- April through October: collapse to the existing `Dryland season` presentation and 98.6° Birkie Fever reading.
+- November through March: keep venue rows visible with `No report`, show `Conditions unavailable`, and clear stale links, grooming details, and wax chips.
+
+An API failure must never manufacture or preserve a recommendation as if it were current.
+
+## State Selection
+
+`conditionsDisplayMode(payload, at)` remains the single state-selection boundary. It evaluates payload health before applying a seasonal fallback.
+
+| Payload | Month | Mode |
+|---|---|---|
+| No top-level error and a non-empty `locations` array | Any month | `live` |
+| Error, missing payload, or empty `locations` | April through October | `off-season` |
+| Error, missing payload, or empty `locations` | November through March | `unavailable` |
+
+This ordering is the core behavior change. A healthy July response is `live`; July itself is not an error state.
+
+## Data Flow and Component Boundaries
+
+No server changes are required.
+
+1. `LiveConditions.client.ts` fetches `GET /api/conditions` immediately and every five minutes while the page is visible.
+2. `conditionsDisplayMode.ts` classifies the response using the truth table above.
+3. A `live` classification uses the existing renderer and exposes the API's temperature, wax band, wax label, provenance, grooming, timestamp, and Birkie status.
+4. A quiet classification uses the existing seasonal failure renderer.
+
+Responsibilities remain separated:
+
+- `site/src/lib/conditionsDisplayMode.ts`: payload and calendar state selection only.
+- `site/src/components/LiveConditions.client.ts`: DOM rendering, refresh, stale-state cleanup, and Birkie audio behavior.
+- `site/src/components/LiveConditions.astro`: markup, responsive layout, visual tokens, and reduced-motion styling. No visual change is expected.
+- `app/conditions/*` and `app/routes/conditions.py`: unchanged data production and caching.
+
+## Accessibility and Brand Constraints
+
+- Preserve `aria-label="Current ski conditions"` and the polite live announcer.
+- Continue announcing only a material change in a previously rendered wax band.
+- Preserve current keyboard, focus, 44px mobile-target, and reduced-motion behavior.
+- Keep the navy-deep, mint, paper, and coral token system unchanged.
+- Keep the current typographic hierarchy and responsive density unchanged.
+- Add no decorative motion or interaction. The data remains the signature device.
+
+## Test Strategy
+
+Implementation follows test-driven development.
+
+1. Change the current healthy-July unit expectation from `off-season` to `live` and observe it fail against the existing selector.
+2. Preserve and run the error-July test, which must remain `off-season`.
+3. Preserve the healthy-January and error-January expectations.
+4. Add a rendered-DOM regression with a July clock and healthy venue payload. Assert that venue cells remain visible and render a summer temperature, the exact `Red wax · klister conditions` label, the red wax chip, the live timestamp, and the API Birkie value.
+5. Keep the existing October-failure to November-failure transition regression. It protects restoration of venue rows when the calendar changes.
+6. Run the complete refinement, sponsor, backend conditions, and Astro diagnostic suites.
+7. Inspect the prominent and compact variants at 390px and 1440px using a mocked healthy summer payload. Require no overflow, no layout shift, and no new seasonal ornament.
+
+## Acceptance Criteria
+
+- A healthy API payload renders as live in January, July, and every other month.
+- A summer visitor sees real venue temperatures and the same wax recommendations a winter visitor would see at those temperatures.
+- The recommendation labels and wax-color encoding remain unchanged.
+- The prominent and compact layouts remain visually identical across seasons for healthy data.
+- Summer and winter failures retain their current distinct fallbacks.
+- The Birkie Fever cell and audio remain unchanged.
+- No backend, content schema, API, or global design-token changes are introduced.
+- Automated and browser verification cover both viewport classes and both seasonal failure branches.

--- a/docs/superpowers/specs/2026-07-19-year-round-wax-recommendations-design.md
+++ b/docs/superpowers/specs/2026-07-19-year-round-wax-recommendations-design.md
@@ -1,7 +1,7 @@
 # Year-Round Wax Recommendations Design
 
 **Date:** 2026-07-19
-**Status:** Approved direction, awaiting written-spec review
+**Status:** Approved
 
 ## Context
 

--- a/site/src/components/LiveConditions.client.ts
+++ b/site/src/components/LiveConditions.client.ts
@@ -94,8 +94,8 @@ function renderInto(root: HTMLElement, data: Resp) {
 function renderQuiet(root: HTMLElement, mode: ConditionsDisplayMode) {
   // Unavailable conditions say it once in the stamp; cells go quiet ("No
   // report") instead of repeating the error four times. Off-season
-  // (April-October), healthy payloads and failures share this dryland path:
-  // no snow is not an outage.
+  // (April-October) is a failure-only fallback; healthy payloads render the
+  // same live temperature and wax instrument year round.
   const offSeason = mode === 'off-season';
   resetSeasonalPresentation(root);
   root.querySelectorAll<HTMLElement>('[data-location]').forEach((el) => {

--- a/site/src/lib/conditionsDisplayMode.ts
+++ b/site/src/lib/conditionsDisplayMode.ts
@@ -9,12 +9,13 @@ export function conditionsDisplayMode(
   payload: unknown,
   at = new Date(),
 ): ConditionsDisplayMode {
-  const month = at.getMonth() + 1;
-  if (month >= 4 && month <= 10) return 'off-season';
+  if (typeof payload === 'object' && payload !== null) {
+    const { error, locations } = payload as ConditionsPayload;
+    if (!error && Array.isArray(locations) && locations.length > 0) {
+      return 'live';
+    }
+  }
 
-  if (typeof payload !== 'object' || payload === null) return 'unavailable';
-  const { error, locations } = payload as ConditionsPayload;
-  return !error && Array.isArray(locations) && locations.length > 0
-    ? 'live'
-    : 'unavailable';
+  const month = at.getMonth() + 1;
+  return month >= 4 && month <= 10 ? 'off-season' : 'unavailable';
 }

--- a/site/tests/conditionsDisplayMode.test.mjs
+++ b/site/tests/conditionsDisplayMode.test.mjs
@@ -14,10 +14,10 @@ const errorPayload = {
   locations: [],
 };
 
-test('uses off-season mode for a healthy, non-empty July payload', () => {
+test('uses live mode for a healthy, non-empty July payload', () => {
   const at = new Date('2026-07-19T12:00:00-05:00');
 
-  assert.equal(conditionsDisplayMode(healthyPayload, at), 'off-season');
+  assert.equal(conditionsDisplayMode(healthyPayload, at), 'live');
 });
 
 test('uses off-season mode for an error/empty July payload', () => {
@@ -36,6 +36,104 @@ test('uses unavailable mode for an error/empty January payload', () => {
   const at = new Date('2027-01-15T12:00:00-06:00');
 
   assert.equal(conditionsDisplayMode(errorPayload, at), 'unavailable');
+});
+
+test('renders real temperatures and wax recommendations from a healthy July payload', async () => {
+  const builtHome = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
+  const assetPath = builtHome.match(
+    /<script\b[^>]*\bsrc="(\/_astro\/LiveConditions\.[^"]+\.js)"[^>]*><\/script>/i,
+  )?.[1];
+  assert.ok(assetPath, 'built home must load the Live Conditions client bundle');
+
+  const dom = new JSDOM(builtHome, { pretendToBeVisual: true });
+  const roots = [...dom.window.document.querySelectorAll('[data-live-conditions]')];
+  assert.ok(roots.length > 0, 'built home must include a Live Conditions root');
+  roots.slice(1).forEach((root) => root.remove());
+  const root = roots[0];
+
+  const original = {
+    Date: globalThis.Date,
+    document: globalThis.document,
+    fetch: globalThis.fetch,
+    setInterval: globalThis.setInterval,
+    setTimeout: globalThis.setTimeout,
+    window: globalThis.window,
+  };
+  const now = '2026-07-19T15:14:56-05:00';
+  const payload = {
+    updated_at: now,
+    locations: [
+      {
+        id: 'wirth',
+        name: 'Theo',
+        temp_f: 88,
+        wind_chill_f: 88,
+        snow_conditions: null,
+        wax_band: 'red',
+        wax_label: 'Red wax · klister conditions',
+        source_url: null,
+        report_date: null,
+        groomed_for: null,
+      },
+    ],
+    birkie: {
+      status: 'early',
+      word: '98.6°',
+      detail: 'No fever yet. Birkie 2027 talk starts in November.',
+    },
+  };
+
+  class TestDate extends original.Date {
+    constructor(...args) {
+      super(...(args.length > 0 ? args : [now]));
+    }
+
+    static now() {
+      return new original.Date(now).getTime();
+    }
+  }
+
+  try {
+    globalThis.Date = TestDate;
+    globalThis.document = dom.window.document;
+    globalThis.window = dom.window;
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => payload,
+    });
+    globalThis.setTimeout = () => 1;
+    globalThis.setInterval = () => 1;
+
+    const assetUrl = new URL(`../dist${assetPath}`, import.meta.url);
+    await import(`${assetUrl.href}?healthy-summer-regression`);
+    await new Promise((resolve) => original.setTimeout(resolve, 0));
+
+    const wirth = root.querySelector('[data-location="wirth"]');
+    assert.ok(wirth, 'home strip must include the Theo venue cell');
+    assert.equal(wirth.hidden, false);
+    assert.equal(wirth.style.display, '');
+    assert.equal(wirth.querySelector('[data-temp]')?.textContent, '88°F');
+    assert.equal(
+      wirth.querySelector('[data-wax]')?.textContent,
+      'Red wax · klister conditions',
+    );
+
+    const chip = wirth.querySelector('[data-wax-chip]');
+    assert.ok(chip, 'prominent venue cell must include its wax chip');
+    assert.equal(chip.hidden, false);
+    assert.equal(chip.dataset.band, 'red');
+    assert.equal(root.querySelector('[data-dryland-label]'), null);
+    assert.match(root.querySelector('[data-updated]')?.textContent ?? '', /^● Live · updated /);
+    assert.equal(root.querySelector('[data-birkie-word]')?.textContent, '98.6°');
+  } finally {
+    globalThis.Date = original.Date;
+    globalThis.document = original.document;
+    globalThis.fetch = original.fetch;
+    globalThis.setInterval = original.setInterval;
+    globalThis.setTimeout = original.setTimeout;
+    globalThis.window = original.window;
+    dom.window.close();
+  }
 });
 
 test('restores venue cells when November unavailable follows October off-season', async () => {
@@ -62,7 +160,7 @@ test('restores venue cells when November unavailable follows October off-season'
   let now = '2026-10-31T12:00:00-05:00';
   let refresh;
   const responses = [
-    { updated_at: now, locations: [{ id: 'wirth' }] },
+    { error: 'Conditions unavailable', locations: [] },
     { error: 'Conditions unavailable', locations: [] },
   ];
 

--- a/site/tests/conditionsDisplayMode.test.mjs
+++ b/site/tests/conditionsDisplayMode.test.mjs
@@ -38,7 +38,7 @@ test('uses unavailable mode for an error/empty January payload', () => {
   assert.equal(conditionsDisplayMode(errorPayload, at), 'unavailable');
 });
 
-test('renders real temperatures and wax recommendations from a healthy July payload', async () => {
+test('renders healthy July data then clears it for a failed July refresh', async () => {
   const builtHome = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
   const assetPath = builtHome.match(
     /<script\b[^>]*\bsrc="(\/_astro\/LiveConditions\.[^"]+\.js)"[^>]*><\/script>/i,
@@ -60,6 +60,7 @@ test('renders real temperatures and wax recommendations from a healthy July payl
     window: globalThis.window,
   };
   const now = '2026-07-19T15:14:56-05:00';
+  let refresh;
   const payload = {
     updated_at: now,
     locations: [
@@ -67,13 +68,13 @@ test('renders real temperatures and wax recommendations from a healthy July payl
         id: 'wirth',
         name: 'Theo',
         temp_f: 88,
-        wind_chill_f: 88,
+        wind_chill_f: 84,
         snow_conditions: null,
         wax_band: 'red',
         wax_label: 'Red wax · klister conditions',
-        source_url: null,
-        report_date: null,
-        groomed_for: null,
+        source_url: 'https://www.skinnyski.com/trails/report.asp?id=123',
+        report_date: '2026-07-18',
+        groomed_for: 'skate',
       },
     ],
     birkie: {
@@ -82,6 +83,7 @@ test('renders real temperatures and wax recommendations from a healthy July payl
       detail: 'No fever yet. Birkie 2027 talk starts in November.',
     },
   };
+  const responses = [payload, errorPayload];
 
   class TestDate extends original.Date {
     constructor(...args) {
@@ -99,10 +101,13 @@ test('renders real temperatures and wax recommendations from a healthy July payl
     globalThis.window = dom.window;
     globalThis.fetch = async () => ({
       ok: true,
-      json: async () => payload,
+      json: async () => responses.shift(),
     });
     globalThis.setTimeout = () => 1;
-    globalThis.setInterval = () => 1;
+    globalThis.setInterval = (callback) => {
+      refresh = callback;
+      return 1;
+    };
 
     const assetUrl = new URL(`../dist${assetPath}`, import.meta.url);
     await import(`${assetUrl.href}?healthy-summer-regression`);
@@ -113,9 +118,21 @@ test('renders real temperatures and wax recommendations from a healthy July payl
     assert.equal(wirth.hidden, false);
     assert.equal(wirth.style.display, '');
     assert.equal(wirth.querySelector('[data-temp]')?.textContent, '88°F');
+    assert.equal(wirth.querySelector('[data-feels]')?.textContent, 'feels 84°');
     assert.equal(
       wirth.querySelector('[data-wax]')?.textContent,
       'Red wax · klister conditions',
+    );
+
+    const sourceLink = wirth.querySelector('a[data-source-link]');
+    assert.ok(sourceLink, 'healthy payload must render its trail report link');
+    assert.equal(
+      sourceLink.getAttribute('href'),
+      'https://www.skinnyski.com/trails/report.asp?id=123',
+    );
+    assert.equal(
+      wirth.querySelector('[data-groomed]')?.textContent,
+      'Groomed skate · Jul 18',
     );
 
     const chip = wirth.querySelector('[data-wax-chip]');
@@ -125,6 +142,30 @@ test('renders real temperatures and wax recommendations from a healthy July payl
     assert.equal(root.querySelector('[data-dryland-label]'), null);
     assert.match(root.querySelector('[data-updated]')?.textContent ?? '', /^● Live · updated /);
     assert.equal(root.querySelector('[data-birkie-word]')?.textContent, '98.6°');
+    assert.equal(root.dataset.updatedAt, now);
+
+    assert.equal(typeof refresh, 'function', 'client must register its refresh interval');
+    refresh();
+    await new Promise((resolve) => original.setTimeout(resolve, 0));
+
+    const venueCells = [...root.querySelectorAll('[data-location]')];
+    assert.equal(venueCells.length, 4);
+    for (const cell of venueCells) {
+      assert.equal(cell.hidden, true, 'summer failure must hide each venue');
+      assert.equal(cell.style.display, 'none', 'summer failure must hide each venue inline');
+      assert.equal(cell.querySelector('[data-temp]')?.textContent, '');
+      assert.equal(cell.querySelector('[data-feels]')?.textContent, '');
+      assert.equal(cell.querySelector('[data-wax]')?.textContent, 'Dryland season');
+      assert.equal(cell.querySelector('[data-wax-chip]')?.hidden, true);
+      assert.equal(cell.querySelector('[data-source-link]'), null);
+      assert.equal(cell.querySelector('[data-groomed]'), null);
+    }
+    assert.equal(root.querySelectorAll('[data-dryland-label]').length, 1);
+    assert.equal(root.dataset.updatedAt, undefined);
+    assert.equal(
+      root.querySelector('[data-updated]')?.textContent,
+      '● Trail reports come back with the snow',
+    );
   } finally {
     globalThis.Date = original.Date;
     globalThis.document = original.document;


### PR DESCRIPTION
## Summary

- render healthy live conditions in every month, preserving the existing temperature and wax instrument
- use April–October `off-season` and November–March `unavailable` only when the payload is unhealthy
- keep all UI, copy, thresholds, Birkie behavior, accessibility, responsive behavior, API, and design tokens unchanged
- add built-client coverage for healthy July rendering, failed-summer cleanup, and the October-to-November failure transition

## Verification

- `npm run test:refinement` — 14/14
- `npm run test:sponsors` — 24/24
- `npx astro check` — 0 errors, 0 warnings, 0 hints
- `pytest tests/conditions tests/wix_scrape -q` — 74/74
- fixed-July Playwright checks — home/about at 390px and 1440px, 4/4; zero overflow and conditions CLS below 0.01
