### PR TITLE
Events: per-option questions, no registration contact, description line breaks

### DIFF
--- a/app/events/service.py
+++ b/app/events/service.py
@@ -49,6 +49,47 @@ def compute_price(
     return option.price_cents, False
 
 
+def questions_for_option(
+    event: Event,
+    option: EventPriceOption | None,
+) -> list[dict]:
+    """Return the event's custom questions that apply to ``option``."""
+    questions = [
+        question
+        for question in (event.custom_questions or [])
+        if isinstance(question, dict)
+    ]
+    if option is None:
+        return questions
+
+    known_names = {existing.name for existing in event.price_options}
+    return [
+        question
+        for question in questions
+        if _question_in_scope(question, option, known_names)
+    ]
+
+
+def _question_in_scope(
+    question: dict,
+    option: EventPriceOption,
+    known_names: set[str],
+) -> bool:
+    scope = question.get("price_options")
+    names = (
+        [name for name in scope if isinstance(name, str)]
+        if isinstance(scope, list)
+        else []
+    )
+    if not names:
+        return True
+    if option.name in names:
+        return True
+    # A scope naming no surviving price option falls open to applying, so
+    # renaming an option cannot silently drop a required question.
+    return not any(name in known_names for name in names)
+
+
 def capacity_available(event: Event) -> bool:
     """Return whether the event has room for another registration."""
     if event.capacity is None:
@@ -110,12 +151,7 @@ def create_registration(
             "Select an active price option for this event."
         )
 
-    contact_email = _normalized_email(payload.get("contact_email"))
-    if not contact_email:
-        errors["contact_email"] = "Contact email is required."
-
     required_registration_fields = (
-        ("contact_phone", "Contact phone"),
         ("emergency_contact_name", "Emergency contact name"),
         ("emergency_contact_phone", "Emergency contact phone"),
     )
@@ -145,7 +181,7 @@ def create_registration(
             errors["team_name"] = "Team name is required for team options."
 
     stored_answers, answer_errors = _validate_answers(
-        event.custom_questions or [],
+        questions_for_option(event, option),
         payload.get("answers"),
     )
     errors.update(answer_errors)
@@ -161,11 +197,14 @@ def create_registration(
         event,
         payload.get("discount_code"),
     )
+    # Participant details are the only contact we collect; the first
+    # participant is who Stripe emails and who the roster lists.
+    primary_participant = validated_participants[0]
     registration = EventRegistration(
         event_id=event.id,
         price_option_id=option.id,
-        contact_email=contact_email,
-        contact_phone=payload["contact_phone"].strip(),
+        contact_email=primary_participant["email"],
+        contact_phone=primary_participant["phone"],
         team_name=_optional_text(team_name),
         emergency_contact_name=payload["emergency_contact_name"].strip(),
         emergency_contact_phone=payload["emergency_contact_phone"].strip(),

--- a/app/events/templates.py
+++ b/app/events/templates.py
@@ -40,6 +40,16 @@ def _validate_question(template_key, index, question):
     ):
         raise ValueError(f"{offender} must have an 'options' list")
 
+    if "price_options" in question and (
+        not isinstance(question["price_options"], list)
+        or not all(
+            isinstance(name, str) for name in question["price_options"]
+        )
+    ):
+        raise ValueError(
+            f"{offender} field 'price_options' must be a list of str"
+        )
+
 
 def _price_option_name(template_key, index, option):
     name = option.get("name") if isinstance(option, dict) else None

--- a/app/routes/admin_events.py
+++ b/app/routes/admin_events.py
@@ -225,9 +225,10 @@ def _replace_price_options(event, raw_value):
         option.active = row["active"]
 
 
-def _validated_questions(raw_value):
+def _validated_questions(raw_value, option_names=None):
     rows = _parse_json_rows(raw_value, "Custom questions")
-    seen_keys = set()
+    known_names = set(option_names or ())
+    scopes_by_key: dict[str, list[set[str]]] = {}
     validated = []
     for index, row in enumerate(rows):
         validate_question(row, index)
@@ -237,14 +238,49 @@ def _validated_questions(raw_value):
             raise ValueError(
                 f"Custom question {index + 1} must have a non-empty key."
             )
-        if key in seen_keys:
-            raise ValueError(f"Custom question key '{key}' is duplicated.")
-        seen_keys.add(key)
-        row["key"] = key.strip()
+        key = key.strip()
+        scope = _validated_question_scope(row, index, known_names)
+        _check_scope_is_disjoint(key, scope, scopes_by_key.get(key, []))
+        scopes_by_key.setdefault(key, []).append(scope)
+        row["key"] = key
         row["options"] = row.get("options", [])
         row["help_text"] = row.get("help_text") or ""
+        row["price_options"] = sorted(scope)
         validated.append(row)
     return validated
+
+
+def _validated_question_scope(row, index, known_names):
+    """Return the question's price-option scope as a set of known names."""
+    scope = row.get("price_options") or []
+    names = {name.strip() for name in scope if isinstance(name, str)}
+    names.discard("")
+    if known_names:
+        unknown = names - known_names
+        if unknown:
+            raise ValueError(
+                f"Custom question {index + 1} is limited to price option "
+                f"'{min(unknown)}', which does not exist on this event."
+            )
+    return names
+
+
+def _check_scope_is_disjoint(key, scope, existing_scopes):
+    """Allow a repeated key only when every scope sharing it is disjoint."""
+    if not existing_scopes:
+        return
+    if not scope or any(not other for other in existing_scopes):
+        raise ValueError(
+            f"Custom question key '{key}' is duplicated. Repeat a key only "
+            "when each copy is limited to different price options."
+        )
+    for other in existing_scopes:
+        overlap = scope & other
+        if overlap:
+            raise ValueError(
+                f"Custom question key '{key}' is used twice for price "
+                f"option '{min(overlap)}'."
+            )
 
 
 def _serialize_price_options(event):
@@ -343,10 +379,15 @@ def _registration_columns(event):
         (f"participant_{position}", f"Participant {position}")
         for position in range(1, max_participants + 1)
     ]
-    question_columns = [
-        (question["key"], question.get("label") or question["key"])
-        for question in (event.custom_questions or [])
-    ]
+    # A key may repeat across price-option scopes; it is still one column.
+    question_columns = []
+    seen_question_keys = set()
+    for question in event.custom_questions or []:
+        key = question["key"]
+        if key in seen_question_keys:
+            continue
+        seen_question_keys.add(key)
+        question_columns.append((key, question.get("label") or key))
     return (
         _REGISTRATION_BASE_COLUMNS
         + participant_columns
@@ -456,7 +497,10 @@ def new_event():
             _replace_price_options(event, price_rows)
         question_rows = request.form.get("custom_questions_json")
         if question_rows is not None:
-            event.custom_questions = _validated_questions(question_rows)
+            event.custom_questions = _validated_questions(
+                question_rows,
+                [option.name for option in event.price_options],
+            )
 
         db.session.add(event)
         db.session.commit()
@@ -492,7 +536,10 @@ def edit_event(event_id):
             _replace_price_options(event, price_rows)
         question_rows = request.form.get("custom_questions_json")
         if question_rows is not None:
-            event.custom_questions = _validated_questions(question_rows)
+            event.custom_questions = _validated_questions(
+                question_rows,
+                [option.name for option in event.price_options],
+            )
 
         db.session.commit()
         flash_success("Event updated successfully.")

--- a/app/static/admin_events.js
+++ b/app/static/admin_events.js
@@ -411,6 +411,9 @@
     var templates = JSON.parse(templateDataNode.textContent || '{}');
     var priceRows = parseRows(priceHidden.value);
     var questionRows = parseRows(questionHidden.value);
+    var priorNames = priceRows.map(function (item) {
+      return (item.name || '').trim();
+    });
 
     function parseRows(rawValue) {
       try {
@@ -510,10 +513,83 @@
           ).checked,
           help_text: row.querySelector(
             '[data-field="help-text"]'
-          ).value.trim()
+          ).value.trim(),
+          price_options: Array.from(
+            row.querySelectorAll('[data-field="scope"]:checked')
+          ).map(function (box) {
+            return box.value;
+          })
         };
       });
       questionHidden.value = JSON.stringify(questionRows);
+    }
+
+    function rawNames() {
+      return priceRows.map(function (item) {
+        return (item.name || '').trim();
+      });
+    }
+
+    function optionNames() {
+      return rawNames().filter(Boolean);
+    }
+
+    // Renaming a price option must carry its question scopes along, or a
+    // rename would orphan them and the save would be rejected.
+    function renameQuestionScopes(before, after) {
+      before.forEach(function (oldName, index) {
+        var newName = after[index];
+        if (!oldName || newName === undefined || newName === oldName) return;
+        dropOrRenameScope(oldName, newName);
+      });
+    }
+
+    function dropOrRenameScope(oldName, newName) {
+      questionRows.forEach(function (question) {
+        var scope = question.price_options;
+        if (!Array.isArray(scope)) return;
+        var at = scope.indexOf(oldName);
+        if (at === -1) return;
+        if (newName) scope[at] = newName;
+        else scope.splice(at, 1);
+      });
+    }
+
+    function scopeControl(item, index) {
+      var names = optionNames();
+      var wrapper = el('div', {
+        class: 'aef-field aef-field-full aef-scope'
+      }, [
+        el('span', {class: 'aef-scope-label'}, ['Applies to options'])
+      ]);
+      if (!names.length) {
+        wrapper.appendChild(el('span', {class: 'aef-hint'}, [
+          'Add a price option first to limit this question.'
+        ]));
+        return wrapper;
+      }
+
+      var scope = Array.isArray(item.price_options)
+        ? item.price_options
+        : [];
+      wrapper.appendChild(el('span', {class: 'aef-hint'}, [
+        scope.length
+          ? 'Asked only for the checked options.'
+          : 'Nothing checked: asked for every option.'
+      ]));
+      var boxes = el('div', {class: 'aef-scope-boxes'});
+      names.forEach(function (name, nameIndex) {
+        var box = el('input', {
+          id: 'question-scope-' + index + '-' + nameIndex,
+          type: 'checkbox',
+          value: name
+        });
+        box.checked = scope.indexOf(name) !== -1;
+        box.dataset.field = 'scope';
+        boxes.appendChild(el('label', {class: 'aef-check'}, [box, name]));
+      });
+      wrapper.appendChild(boxes);
+      return wrapper;
     }
 
     function renderPrices() {
@@ -596,12 +672,24 @@
           type: 'button',
           class: 'aef-remove',
           onclick: function () {
+            var removed = (priceRows[index] || {}).name;
             priceRows.splice(index, 1);
+            if (removed) dropOrRenameScope(removed.trim(), '');
+            priorNames = rawNames();
             renderPrices();
+            renderQuestions();
           }
         }, ['Remove option']));
         row.addEventListener('input', syncPrices);
-        row.addEventListener('change', syncPrices);
+        // Scope checkboxes rebuild on blur, not on every keystroke, so
+        // renaming an option does not steal focus mid-typing.
+        row.addEventListener('change', function () {
+          syncPrices();
+          var current = rawNames();
+          renameQuestionScopes(priorNames, current);
+          priorNames = current;
+          renderQuestions();
+        });
         priceContainer.appendChild(row);
       });
       syncPrices();
@@ -680,6 +768,7 @@
           required,
           'Required'
         ]));
+        grid.appendChild(scopeControl(item, index));
         row.appendChild(grid);
         row.appendChild(el('button', {
           type: 'button',
@@ -706,7 +795,9 @@
           participant_roles: ['Participant'],
           active: true
         });
+        priorNames = rawNames();
         renderPrices();
+        renderQuestions();
       });
     document.getElementById('add-question')
       .addEventListener('click', function () {
@@ -721,13 +812,27 @@
         renderQuestions();
       });
     if (templateSelect) {
+      var templateKeyBefore = templateSelect.value;
       templateSelect.addEventListener('change', function () {
+        // Applying a template replaces price options wholesale, which would
+        // discard member prices an existing event depends on.
+        var replacesLiveData = priceRows.length || questionRows.length;
+        if (replacesLiveData && !window.confirm(
+          'Applying this template replaces all price options and custom '
+            + 'questions below, including any member prices. Continue?'
+        )) {
+          templateSelect.value = templateKeyBefore;
+          return;
+        }
+
         var selected = templates[templateSelect.value] || {
           price_options: [],
           custom_questions: []
         };
         priceRows = clone(selected.price_options || []);
         questionRows = clone(selected.custom_questions || []);
+        priorNames = rawNames();
+        templateKeyBefore = templateSelect.value;
         renderPrices();
         renderQuestions();
       });

--- a/app/static/event_registration.js
+++ b/app/static/event_registration.js
@@ -9,6 +9,18 @@
   const optionsById = new Map(
     eventData.priceOptions.map(option => [String(option.id), option])
   );
+  const knownOptionNames = new Set(
+    eventData.priceOptions.map(option => option.name)
+  );
+
+  // Mirrors questions_for_option() on the server: an empty scope applies to
+  // every option, and a scope naming no surviving option falls open to
+  // applying rather than silently dropping a required question.
+  function questionAppliesTo(scope, optionName) {
+    if (!Array.isArray(scope) || scope.length === 0) return true;
+    if (scope.includes(optionName)) return true;
+    return !scope.some(name => knownOptionNames.has(name));
+  }
 
   const stripeCardStyles = {
     style: {
@@ -106,6 +118,9 @@
       const isTeam = option.participantRoles.length > 1;
       teamNameField.classList.toggle('hidden', !isTeam);
       teamName.required = isTeam;
+      teamName.disabled = !isTeam;
+
+      this.applyQuestionScopes(option.name);
 
       const isFree = option.priceCents === 0;
       document.getElementById('card-field').classList.toggle('hidden', isFree);
@@ -120,6 +135,32 @@
           );
         });
       }
+    }
+
+    applyQuestionScopes(optionName) {
+      let visibleCount = 0;
+      form.querySelectorAll('[data-question-field]').forEach(field => {
+        let scope = [];
+        try {
+          scope = JSON.parse(field.dataset.questionScope || '[]');
+        } catch (error) {
+          scope = [];
+        }
+
+        const applies = questionAppliesTo(scope, optionName);
+        if (applies) visibleCount += 1;
+        field.classList.toggle('hidden', !applies);
+        // Disabling keeps out-of-scope answers out of validation and out of
+        // the payload while preserving what was typed if the option changes
+        // back.
+        field.querySelectorAll('[data-question-key]').forEach(input => {
+          input.disabled = !applies;
+        });
+      });
+
+      // Don't leave the heading stranded over an empty section.
+      const section = document.getElementById('event-questions');
+      if (section) section.classList.toggle('hidden', visibleCount === 0);
     }
 
     renderParticipants(roles) {
@@ -212,9 +253,11 @@
 
     collectPayload() {
       const answers = {};
-      form.querySelectorAll('[data-question-key]').forEach(input => {
-        answers[input.dataset.questionKey] = input.value;
-      });
+      form
+        .querySelectorAll('[data-question-key]:not([disabled])')
+        .forEach(input => {
+          answers[input.dataset.questionKey] = input.value;
+        });
 
       const participants = Array.from(
         form.querySelectorAll('[data-participant]')
@@ -226,11 +269,15 @@
         return participant;
       });
 
+      // Only teams have a team name; don't ship a stale one left behind by a
+      // registrant who switched away from a team option.
+      const isTeam = this.selectedOption.participantRoles.length > 1;
+
       return {
         price_option_id: this.selectedOption.id,
-        contact_email: document.getElementById('contact-email').value,
-        contact_phone: document.getElementById('contact-phone').value,
-        team_name: document.getElementById('team-name').value,
+        team_name: isTeam
+          ? document.getElementById('team-name').value
+          : null,
         emergency_contact_name: document.getElementById(
           'emergency-contact-name'
         ).value,
@@ -293,8 +340,8 @@
               card: this.card,
               billing_details: {
                 name: payload.participants[0].name,
-                email: payload.contact_email,
-                phone: payload.contact_phone
+                email: payload.participants[0].email,
+                phone: payload.participants[0].phone
               }
             }
           }
@@ -320,6 +367,16 @@
       }
     }
 
+    // A key can repeat across scopes, so match the one currently in play.
+    findQuestionInput(questionKey) {
+      const inputs = Array.from(
+        form.querySelectorAll('[data-question-key]:not([disabled])')
+      );
+      return (
+        inputs.find(input => input.dataset.questionKey === questionKey) || null
+      );
+    }
+
     showServerErrors(errors) {
       if (!errors || typeof errors !== 'object') {
         this.showError(errors || 'Registration failed. Please try again.');
@@ -329,8 +386,6 @@
       const messages = Object.values(errors);
       Object.keys(errors).forEach(key => {
         const fieldId = {
-          contact_email: 'contact-email',
-          contact_phone: 'contact-phone',
           team_name: 'team-name',
           emergency_contact_name: 'emergency-contact-name',
           emergency_contact_phone: 'emergency-contact-phone'
@@ -341,7 +396,7 @@
         const field = fieldId
           ? document.getElementById(fieldId)
           : questionKey
-            ? document.getElementById(`question-${questionKey}`)
+            ? this.findQuestionInput(questionKey)
             : null;
         if (field) field.classList.add('field-error');
       });

--- a/app/templates/admin/event_form.html
+++ b/app/templates/admin/event_form.html
@@ -19,6 +19,9 @@
 #admin-event-form .aef-remove{margin-top:12px;min-height:36px;border:1px solid #fecaca;border-radius:7px;background:#fcfefd;color:#991b1b;padding:0 11px;font-size:12px;font-weight:650;cursor:pointer}
 #admin-event-form .aef-add{min-height:40px;border:1px solid #cbd5e1;border-radius:8px;background:#fcfefd;color:#1c2c44;padding:0 13px;font-size:13px;font-weight:650;cursor:pointer}
 #admin-event-form .aef-add:focus-visible,#admin-event-form .aef-remove:focus-visible{outline:2px solid #1c2c44;outline-offset:2px}
+#admin-event-form .aef-scope-label{font-size:12px;font-weight:650;color:#475569}
+#admin-event-form .aef-scope-boxes{display:flex;flex-wrap:wrap;gap:6px 18px}
+#admin-event-form .aef-hint{font-size:12px;color:#64748b}
 #admin-event-form .aef-empty{border:1px dashed #cbd5e1;border-radius:10px;padding:18px;color:#64748b;font-size:13px;text-align:center}
 @media(max-width:780px){
   #admin-event-form .aef-field,#admin-event-form .aef-field-wide{grid-column:1/-1}

--- a/app/templates/events/registration.html
+++ b/app/templates/events/registration.html
@@ -33,7 +33,7 @@
             <span>{{ event.location }}</span>
           </div>
           {% if event.description %}
-            <p style="max-width: 62ch; margin: 20px auto 0; color: var(--text-secondary); line-height: 1.6;">{{ event.description }}</p>
+            <p style="max-width: 62ch; margin: 20px auto 0; color: var(--text-secondary); line-height: 1.6; white-space: pre-line; text-align: left;">{{ event.description }}</p>
           {% endif %}
           {% if event.details_url %}
             <p style="margin: 12px 0 0;"><a href="{{ event.details_url }}" target="_blank" rel="noopener noreferrer">View full event details</a></p>
@@ -72,29 +72,14 @@
             <section class="form-section" aria-labelledby="participants-title">
               <h2 class="form-section__title" id="participants-title">Participant details</h2>
               <p class="form-section__subtitle" id="option-description"></p>
-              <div id="participants-container"></div>
-            </section>
-
-            <hr class="form-divider">
-
-            <section class="form-section" aria-labelledby="contact-title">
-              <h2 class="form-section__title" id="contact-title">Registration contact</h2>
-              <p class="form-section__subtitle">We will use this contact if there is a question about the registration.</p>
-              <div class="form-row form-row--pair">
-                <div class="form-field">
-                  <label class="form-field__label" for="contact-email">Email address</label>
-                  <input type="email" id="contact-email" class="form-input" autocomplete="email" required>
-                </div>
-                <div class="form-field">
-                  <label class="form-field__label" for="contact-phone">Phone number</label>
-                  <input type="tel" id="contact-phone" class="form-input" autocomplete="tel" required>
-                </div>
-              </div>
               <div class="form-field hidden" id="team-name-field">
                 <label class="form-field__label" for="team-name">Team name</label>
                 <input type="text" id="team-name" class="form-input" autocomplete="organization">
               </div>
+              <div id="participants-container"></div>
             </section>
+
+            <hr class="form-divider">
 
             <section class="form-section" aria-labelledby="emergency-title">
               <h2 class="form-section__title" id="emergency-title">Emergency contact</h2>
@@ -112,17 +97,22 @@
             </section>
 
             {% if event.custom_questions %}
-              <section class="form-section" aria-labelledby="event-questions-title">
+              <section class="form-section" id="event-questions" aria-labelledby="event-questions-title">
                 <h2 class="form-section__title" id="event-questions-title">Event questions</h2>
                 <p class="form-section__subtitle">A few details for event organizers.</p>
                 {% for question in event.custom_questions %}
-                  <div class="form-field">
-                    <label class="form-field__label" for="question-{{ question.key }}">
+                  {# A key may repeat across price-option scopes, so ids are index-based. #}
+                  <div
+                    class="form-field"
+                    data-question-field="{{ loop.index0 }}"
+                    data-question-scope='{{ (question.price_options or [])|tojson }}'
+                  >
+                    <label class="form-field__label" for="question-{{ loop.index0 }}">
                       {{ question.label }}{% if question.required %} <span aria-hidden="true">*</span>{% endif %}
                     </label>
                     {% if question.type == 'choice' %}
                       <select
-                        id="question-{{ question.key }}"
+                        id="question-{{ loop.index0 }}"
                         class="form-input"
                         data-question-key="{{ question.key }}"
                         {% if question.required %}required{% endif %}
@@ -135,7 +125,7 @@
                     {% else %}
                       <input
                         type="text"
-                        id="question-{{ question.key }}"
+                        id="question-{{ loop.index0 }}"
                         class="form-input"
                         data-question-key="{{ question.key }}"
                         {% if question.required %}required{% endif %}

--- a/config/event_templates.yaml
+++ b/config/event_templates.yaml
@@ -1,25 +1,39 @@
 templates:
   dry_tri:
     name: Dry Tri (race)
+    # Option names are referenced by the question scopes below, so renaming
+    # one here means updating every price_options list that mentions it.
     price_options:
-      - name: Individual
+      - name: Individual Triathlon
         description: Complete all three legs yourself
         price_cents: 5500
+        member_price_cents: 3500
         participant_roles: ["Participant"]
-      - name: Team of 3
+      - name: Relay Triathlon
         description: 'One registration covers your whole team. If the same participant will complete multiple legs, enter their information again.'
         price_cents: 10500
+        member_price_cents: 7500
         participant_roles: ["Rollerskier", "Mountain Biker", "Trail Runner"]
       - name: Run-only 6K
         description: Just the 6K trail run
         price_cents: 3000
+        member_price_cents: 1500
         participant_roles: ["Participant"]
     custom_questions:
+      # Two scoped copies of one key: individual entries can be non-binary,
+      # relay teams can be mixed. They share a single roster column.
       - key: competition_gender
         label: "Competition gender"
         type: choice
-        options: ["Men", "Women", "Mixed / non-binary"]
+        options: ["Men", "Women", "Non-binary"]
         required: true
+        price_options: ["Individual Triathlon", "Run-only 6K"]
+      - key: competition_gender
+        label: "Competition gender"
+        type: choice
+        options: ["Men", "Women", "Mixed"]
+        required: true
+        price_options: ["Relay Triathlon"]
       - key: club
         label: "Club(s) or team(s) you represent (e.g., TCSC, LNR)"
         type: text
@@ -35,6 +49,7 @@ templates:
           - "Long course (18K roll, 17K ride, 11K run)"
           - "Short course (9K roll, 9K ride, 6K run)"
         required: true
+        price_options: ["Individual Triathlon", "Relay Triathlon"]
       - key: wave
         label: "What is your preferred wave? (We may not be able to accommodate requested wave)"
         type: choice
@@ -43,6 +58,7 @@ templates:
           - "Wave 2 (strong finish)"
           - "Wave 3 (focused on completion)"
         required: false
+        price_options: ["Individual Triathlon", "Relay Triathlon"]
   social:
     name: Social event
     price_options:

--- a/docs/superpowers/notes/2026-07-28-dry-tri-question-scoping-admin-steps.md
+++ b/docs/superpowers/notes/2026-07-28-dry-tri-question-scoping-admin-steps.md
@@ -1,0 +1,63 @@
+# Dry Tri 2026 — admin steps after the question-scoping deploy
+
+The per-option question feature ships in code, but the **live event keeps its own
+copy of the questions JSON**. Production still has the five old unscoped
+questions until someone edits them in the admin. These are those steps.
+
+Production state at time of writing (event is `draft`, **0 registrations**, so
+nothing here can disturb a registrant):
+
+| Price option | Price | Member price |
+|---|---|---|
+| Individual Triathlon | $55.00 | $35.00 |
+| Relay Triathlon | $105.00 | $75.00 |
+| Run-only 6K | $30.00 | $15.00 |
+
+Discount code on the event: `TCSC2026`.
+
+## Do not touch the template dropdown
+
+On `/admin/events/<id>/edit`, changing **Event template** replaces every price
+option and question with the template's, which would wipe the three member
+prices above and silently stop `TCSC2026` from discounting anything. There is
+now a confirmation prompt on that dropdown — decline it. Everything below is
+done by hand in the Custom questions editor.
+
+## Steps
+
+1. Go to `/admin/events`, open **TCSC Dry Triathlon 2026** → Edit.
+2. In **Custom questions**, each question now has an **Applies to options** row
+   with a checkbox per price option. Nothing checked = asked for every option.
+3. Edit the existing `competition_gender` question:
+   - Options (one per line): `Men`, `Women`, `Non-binary`
+   - Applies to options: check **Individual Triathlon** and **Run-only 6K**
+4. Add a second question with the **same key** `competition_gender`:
+   - Label: `Competition gender`, Type: Choice, Required: yes
+   - Options: `Men`, `Women`, `Mixed`
+   - Applies to options: check **Relay Triathlon** only
+   Sharing the key is deliberate — the two variants land in one
+   `competition_gender` column in the registrations CSV. The save is rejected if
+   the scopes ever overlap, so they cannot both apply to the same option.
+5. Leave `club` and `city_state` with nothing checked (asked of everyone).
+6. On `course` and `wave`, check **Individual Triathlon** and **Relay
+   Triathlon** only. That is what stops run-only entrants being asked which
+   course and wave they want.
+7. Save, then open `/events/dry-tri-2026` (admin session shows the draft) and
+   click through all three options to confirm the questions change.
+
+## What to expect on the public page
+
+- No "Registration contact" section. Participant details are the only contact
+  collected, and the Stripe receipt goes to **participant #1** — for a relay
+  team, whoever is entered first.
+- Team name sits with the participant details and appears only for the relay
+  option.
+- The event description now renders its line breaks, so the schedule list shows
+  one item per line.
+
+## Open question for the organizers
+
+`TCSC2026` is a single shared code with no membership check and no usage cap —
+anyone who has the string gets member pricing (about 36% off). If it is meant to
+be member-only, use something unguessable and distribute it through the member
+Slack or newsletter.

--- a/docs/superpowers/notes/2026-07-28-dry-tri-question-scoping-admin-steps.md
+++ b/docs/superpowers/notes/2026-07-28-dry-tri-question-scoping-admin-steps.md
@@ -15,15 +15,37 @@ nothing here can disturb a registrant):
 
 Discount code on the event: `TCSC2026`.
 
-## Do not touch the template dropdown
+## Fast path: re-apply the dry_tri template
 
-On `/admin/events/<id>/edit`, changing **Event template** replaces every price
-option and question with the template's, which would wipe the three member
-prices above and silently stop `TCSC2026` from discounting anything. There is
-now a confirmation prompt on that dropdown — decline it. Everything below is
-done by hand in the Custom questions editor.
+The `dry_tri` template in `config/event_templates.yaml` now matches production
+exactly — same option names, descriptions, prices, and member prices — and
+carries the correctly scoped questions. So the quickest correct route is:
 
-## Steps
+1. `/admin/events` → **TCSC Dry Triathlon 2026** → Edit.
+2. Set **Event template** to **Dry Tri (race)** and accept the confirmation.
+3. Save. Spot-check the three options and their questions on
+   `/events/dry-tri-2026`.
+
+What this does and does not touch:
+
+- **Replaced:** price options and custom questions, with values identical to
+  what is already there apart from the question scopes.
+- **Untouched:** description, dates, location, capacity, status, and the
+  `TCSC2026` discount code. The dropdown only rewrites the two hidden JSON
+  fields client-side; the edit route never calls `apply_template`.
+- **Caveat:** it deletes and recreates the price option rows, so they get new
+  IDs. Harmless at 0 registrations, but `_replace_price_options` refuses to
+  remove an option that has registrations — so once anyone signs up, the
+  dropdown becomes a hard error. Do this before the event goes active.
+
+The confirmation prompt exists because for an event whose admin config has
+drifted from its template (the migrated socials, or a hand-tuned future Dry
+Tri), the same click would discard that drift, including member prices.
+
+## Manual path
+
+Use this if the template and the live event have diverged, or you would rather
+not recreate the price option rows.
 
 1. Go to `/admin/events`, open **TCSC Dry Triathlon 2026** → Edit.
 2. In **Custom questions**, each question now has an **Applies to options** row

--- a/docs/superpowers/specs/2026-07-28-events-registration-fix-pass-design.md
+++ b/docs/superpowers/specs/2026-07-28-events-registration-fix-pass-design.md
@@ -1,0 +1,195 @@
+# Events Registration Fix Pass — Design
+
+**Date:** 2026-07-28
+**Driver:** Feedback from the club's events organizer after reviewing the Dry Tri 2026 draft.
+**Scope:** Public event registration form + admin event editor. No schema migration.
+
+## Background
+
+The generic Events system shipped 2026-07-25 (`docs/superpowers/specs/2026-07-24-generic-events-system-design.md`).
+The Dry Tri 2026 event is seeded in production as a **draft** with zero registrations, so
+behavioural changes here carry no risk to live registrant data.
+
+Custom questions are currently **per-event**: every question renders for every price option.
+The organizer needs them to differ by which entry option the registrant picked, and needs to
+manage that themselves in `/admin/events` rather than through a code change.
+
+### Production state (read-only query, 2026-07-27)
+
+| Price option | Price | Member price |
+|---|---|---|
+| Individual Triathlon | $55.00 | $35.00 |
+| Relay Triathlon | $105.00 | $75.00 |
+| Run-only 6K | $30.00 | $15.00 |
+
+Event discount code: `TCSC2026`. This is verified working — `compute_price` requires the event
+code to be set, to match case-insensitively, and the option to carry a `member_price_cents`;
+all three hold for all three options.
+
+Two facts from that query shape the design:
+
+1. **Live option names differ from the YAML template.** Production uses "Individual Triathlon"
+   and "Relay Triathlon"; `config/event_templates.yaml` says "Individual" and "Team of 3".
+   Question scoping references options by name, so the template names are updated to match
+   production to prevent drift.
+2. **The admin template dropdown is a money footgun.** On the edit form, changing it replaces
+   price options *and* questions, which would wipe the member prices above and silently disable
+   `TCSC2026`. This pass adds a confirmation guard.
+
+## Out of scope
+
+- Migrating the live event's `custom_questions` JSON. The organizer will edit it in
+  `/admin/events` — that is the point of the feature.
+- Homepage event-card description rendering (a five-line schedule inside a card would break the
+  card layout; the card should collapse).
+- The stale `pickleball` draft event in production.
+- Discount-code hardening (single shared guessable string, no membership check, no usage cap).
+  Flagged to the user as a policy question, not changed here.
+
+## Changes
+
+### 1. Description line breaks
+
+`event.description` renders inside a plain `<p>`, so HTML collapses its newlines. The stored
+text already contains the intended blank lines and `- 7:30 AM` schedule bullets.
+
+**Fix:** `white-space: pre-line` on the description paragraph in
+`app/templates/events/registration.html`. Rendering-only; no data change.
+
+### 2. Drop the registration-contact section
+
+The "Registration contact" section (email + phone) is removed from the public form. Participant
+information is sufficient.
+
+`EventRegistration.contact_email` and `contact_phone` are `NOT NULL` and feed the Stripe
+`receipt_email`, the payment metadata, the admin roster, and the CSV export. Rather than migrate
+them to nullable, the server **derives** them from participant #1:
+
+- `create_registration` no longer requires `contact_email` / `contact_phone` in the payload.
+- After participant validation succeeds, `contact_email` = participant 1's email and
+  `contact_phone` = participant 1's phone.
+- Any client-supplied `contact_email` / `contact_phone` is **ignored**, not trusted.
+- If participant validation fails, the participant errors surface as they do today; no
+  `contact_email` error is emitted.
+
+Consequence to accept: the Stripe receipt goes to participant #1, so for a relay team it lands on
+whoever was entered first. The roster's `contact_email` / `contact_phone` columns remain and now
+duplicate participant 1 — kept, because roster consumers already read them.
+
+### 3. Team name moves into participant details
+
+The team-name field moves from the removed contact section into the "Participant details"
+section, rendered above the participant cards and shown only when the selected option has more
+than one participant role. Server-side validation is unchanged — `team_name` is already required
+when `option.participant_count > 1`.
+
+Because it is now rendered by `event_registration.js` alongside participants rather than living
+in static markup, the `showServerErrors` field map keeps its `team_name` entry pointing at the
+same element id.
+
+### 4. Per-option question scoping
+
+Each custom question gains an optional `price_options` field: a list of price-option **names**
+the question applies to. Absent, missing, or empty means **all options** — so every existing
+question keeps its current behaviour with no data change.
+
+```yaml
+- key: course
+  label: "Which race will you participate in?"
+  type: choice
+  options: [...]
+  required: true
+  price_options: ["Individual Triathlon", "Relay Triathlon"]
+```
+
+**Schema validation** (`app/events/templates.py::_validate_question`): if present,
+`price_options` must be a list of strings.
+
+**Public rendering** (`registration.html` + `event_registration.js`): all questions render once.
+On option change, questions outside the selected option's scope are hidden *and their inputs
+disabled*, so both `form.checkValidity()` and `collectPayload()` skip them. Enabling and
+disabling — rather than adding and removing DOM — preserves any answer the registrant already
+typed if they switch options and switch back.
+
+**Server filtering** (`app/events/service.py`): `_validate_answers` receives only the questions
+in scope for the chosen option. Out-of-scope answers are neither required nor stored, so a
+client cannot smuggle in an answer to a question its option should not have been asked.
+
+**Unresolvable scopes fail open to shown.** A scope naming a price option that no longer exists
+falls back to rendering the question, matching the codebase's fail-open convention. A required
+question appearing when it need not is benign; silently dropping one is not.
+
+### 5. Disjoint-scope duplicate keys
+
+`_validated_questions` in `app/routes/admin_events.py` currently rejects any duplicate key. It is
+relaxed to allow a repeated key **only when the scopes of every question sharing it are pairwise
+disjoint and none of them is unscoped** (an unscoped question means all options, so it can never
+be disjoint from anything). Overlapping or unscoped duplicates still raise.
+
+This lets one logical question with per-option answer sets occupy a single roster column.
+
+Two supporting changes:
+
+- **Admin save validates scope names.** Every name in a `price_options` list must match a price
+  option being saved with the event, so the editor cannot create an orphaned scope. (The public
+  renderer still fails open, for data that predates this check.)
+- **`_registration_columns` dedupes question columns by key**, preserving first-seen order.
+  Without this, the two `competition_gender` variants would emit two identical columns.
+
+### 6. Dry Tri question content
+
+Delivered via the mechanism above, in `config/event_templates.yaml`. Price option names in the
+template are also renamed to match production.
+
+| Question | Individual Triathlon | Relay Triathlon | Run-only 6K |
+|---|---|---|---|
+| `competition_gender` | Men / Women / **Non-binary** | Men / Women / **Mixed** | Men / Women / **Non-binary** |
+| `club` | yes | yes | yes |
+| `city_state` | yes | yes | yes |
+| `course` | yes | yes | — |
+| `wave` | yes | yes | — |
+
+`competition_gender` is two entries sharing one key with disjoint scopes: one scoped to
+Individual + Run-only offering Non-binary, one scoped to Relay offering Mixed. The run-only 6K is
+an individual entry, so it takes the non-binary set. Run-only participants are asked neither
+`course` nor `wave`.
+
+### 7. Admin editor
+
+- **"Applies to options" control per question:** a checkbox per current price-option name, none
+  checked meaning all options. Checkboxes are built from the live `priceRows` in the editor, so
+  renaming an option and then scoping a question works within a single unsaved edit. Questions
+  re-render on price-option `change` (blur), not `input`, to avoid stealing focus mid-typing.
+- **Template dropdown confirmation:** on an existing event, changing the template prompts for
+  confirmation before replacing price options and questions, because doing so silently discards
+  member prices.
+
+## Testing
+
+`tests/events/` has 38 references to the contact fields across 6 files; all registration payload
+fixtures drop `contact_email` / `contact_phone`.
+
+New coverage:
+
+- Contact email and phone are derived from participant 1; a client-supplied contact value is
+  ignored.
+- A question scoped to other options is neither required nor stored for the chosen option.
+- An unscoped question still applies to every option.
+- A scope naming an unknown option falls open to applying.
+- Duplicate keys with disjoint scopes save; overlapping or unscoped duplicates raise.
+- Admin save rejects a scope naming a nonexistent price option.
+- Roster columns contain exactly one `competition_gender` column.
+- The `dry_tri` template loads with the scoped questions and matches the table in §6.
+
+## Files
+
+| File | Change |
+|---|---|
+| `app/templates/events/registration.html` | `pre-line` description; remove contact section; move team name; render scoped questions |
+| `app/static/event_registration.js` | Team name in participant section; scope-driven enable/disable; drop contact from payload |
+| `app/events/service.py` | Derive contact from participant 1; filter questions by option scope |
+| `app/events/templates.py` | Validate optional `price_options` on a question |
+| `app/routes/admin_events.py` | Disjoint-scope key rule; validate scope names; dedupe question columns |
+| `app/static/admin_events.js` | Scope checkboxes; template-change confirmation |
+| `config/event_templates.yaml` | Scoped Dry Tri questions; option names matched to production |
+| `tests/events/*.py` | Drop contact fields; new scoping/derivation coverage |

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "tailwind:watch": "tailwindcss -i ./app/static/css/tailwind-input.css -o ./app/static/css/tailwind-output.css --watch",
     "tailwind:build": "tailwindcss -i ./app/static/css/tailwind-input.css -o ./app/static/css/tailwind-output.css --minify",
-    "test:practice-reactions": "node --test tests/js/practice_plan_reactions.test.js tests/js/practice_plan_reaction_editor.test.js tests/js/toast.test.js tests/js/lead_picker.test.js tests/js/draft_publish.test.js"
+    "test:practice-reactions": "node --test tests/js/practice_plan_reactions.test.js tests/js/practice_plan_reaction_editor.test.js tests/js/toast.test.js tests/js/lead_picker.test.js tests/js/draft_publish.test.js",
+    "test:events": "node --test tests/js/event_registration_scopes.test.js tests/js/admin_event_scopes.test.js"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",

--- a/tests/events/conftest.py
+++ b/tests/events/conftest.py
@@ -8,6 +8,8 @@ from app.models import db
 
 TEST_EVENT_SLUGS = (
     "admin-grid-test",
+    "admin-scope-test",
+    "admin-scope-roster-test",
     "admin-registration-test",
     "admin-duplicate-test",
     "admin-duplicate-test-copy",

--- a/tests/events/test_admin.py
+++ b/tests/events/test_admin.py
@@ -2,6 +2,7 @@
 
 import csv
 from datetime import date, datetime, timedelta
+import json
 from io import StringIO
 from unittest.mock import patch
 
@@ -172,8 +173,8 @@ def test_create_from_dry_tri_template_copies_three_price_options(
     event = Event.query.filter_by(slug="dry-tri-2026").one()
     assert event.template_key == "dry_tri"
     assert [option.name for option in event.price_options] == [
-        "Individual",
-        "Team of 3",
+        "Individual Triathlon",
+        "Relay Triathlon",
         "Run-only 6K",
     ]
 
@@ -488,3 +489,199 @@ def test_cancel_paid_registration_uses_shared_refund_helper(
     refund.assert_called_once_with(payment)
     db_session.session.refresh(registration)
     assert registration.status == RegistrationStatus.REFUNDED
+
+
+def _edit_form(event, price_options_json, custom_questions_json):
+    return {
+        "slug": event.slug,
+        "name": event.name,
+        "description": event.description,
+        "location": event.location,
+        "event_date": event.event_date.strftime("%Y-%m-%dT%H:%M"),
+        "signup_start": event.signup_start.strftime("%Y-%m-%dT%H:%M"),
+        "signup_end": event.signup_end.strftime("%Y-%m-%dT%H:%M"),
+        "capacity": str(event.capacity),
+        "status": event.status,
+        "audience": event.audience,
+        "details_url": "",
+        "discount_code": "",
+        "price_options_json": price_options_json,
+        "custom_questions_json": custom_questions_json,
+    }
+
+
+_TWO_OPTIONS_JSON = json.dumps(
+    [
+        {
+            "name": "Individual Triathlon",
+            "description": "",
+            "price_cents": 5500,
+            "member_price_cents": 3500,
+            "participant_roles": ["Participant"],
+            "active": True,
+        },
+        {
+            "name": "Relay Triathlon",
+            "description": "",
+            "price_cents": 10500,
+            "member_price_cents": 7500,
+            "participant_roles": [
+                "Rollerskier",
+                "Mountain Biker",
+                "Trail Runner",
+            ],
+            "active": True,
+        },
+    ]
+)
+
+
+def _gender_question(options, scope):
+    return {
+        "key": "competition_gender",
+        "label": "Competition gender",
+        "type": "choice",
+        "options": options,
+        "required": True,
+        "price_options": scope,
+    }
+
+
+def test_edit_saves_disjoint_scoped_duplicate_question_keys(
+    admin_client,
+    db_session,
+):
+    event = _event("admin-scope-test")
+    db_session.session.add(event)
+    db_session.session.commit()
+
+    response = admin_client.post(
+        f"/admin/events/{event.id}/edit",
+        data=_edit_form(
+            event,
+            _TWO_OPTIONS_JSON,
+            json.dumps(
+                [
+                    _gender_question(
+                        ["Men", "Women", "Non-binary"],
+                        ["Individual Triathlon"],
+                    ),
+                    _gender_question(
+                        ["Men", "Women", "Mixed"],
+                        ["Relay Triathlon"],
+                    ),
+                ]
+            ),
+        ),
+    )
+
+    assert response.status_code == 302
+    db_session.session.refresh(event)
+    assert [
+        question["price_options"] for question in event.custom_questions
+    ] == [["Individual Triathlon"], ["Relay Triathlon"]]
+
+
+@pytest.mark.parametrize(
+    ("first_scope", "second_scope", "message"),
+    [
+        (
+            ["Individual Triathlon"],
+            ["Individual Triathlon"],
+            "is used twice for price",
+        ),
+        (
+            [],
+            ["Relay Triathlon"],
+            "Repeat a key only when each copy is limited",
+        ),
+        (
+            ["Individual Triathlon"],
+            [],
+            "Repeat a key only when each copy is limited",
+        ),
+    ],
+)
+def test_edit_rejects_duplicate_keys_that_are_not_disjoint(
+    admin_client,
+    db_session,
+    first_scope,
+    second_scope,
+    message,
+):
+    event = _event("admin-scope-test")
+    db_session.session.add(event)
+    db_session.session.commit()
+
+    response = admin_client.post(
+        f"/admin/events/{event.id}/edit",
+        data=_edit_form(
+            event,
+            _TWO_OPTIONS_JSON,
+            json.dumps(
+                [
+                    _gender_question(["Men", "Women"], first_scope),
+                    _gender_question(["Men", "Women"], second_scope),
+                ]
+            ),
+        ),
+    )
+
+    assert response.status_code == 400
+    assert message in response.get_data(as_text=True)
+    db_session.session.refresh(event)
+    assert event.custom_questions == []
+
+
+def test_edit_rejects_a_scope_naming_an_unknown_price_option(
+    admin_client,
+    db_session,
+):
+    event = _event("admin-scope-test")
+    db_session.session.add(event)
+    db_session.session.commit()
+
+    response = admin_client.post(
+        f"/admin/events/{event.id}/edit",
+        data=_edit_form(
+            event,
+            _TWO_OPTIONS_JSON,
+            json.dumps(
+                [_gender_question(["Men", "Women"], ["Solo Triathlon"])]
+            ),
+        ),
+    )
+
+    assert response.status_code == 400
+    body = response.get_data(as_text=True)
+    assert "Solo Triathlon" in body
+    assert "which does not exist on this event" in body
+    db_session.session.refresh(event)
+    assert event.custom_questions == []
+
+
+def test_registrations_roster_lists_a_repeated_question_key_once(
+    admin_client,
+    db_session,
+):
+    event = _event(
+        "admin-scope-roster-test",
+        custom_questions=[
+            _gender_question(["Men", "Women", "Non-binary"], ["Individual"]),
+            _gender_question(["Men", "Women", "Mixed"], ["Team of 3"]),
+        ],
+    )
+    registration = _registration(event)
+    registration.answers = {"competition_gender": "Mixed"}
+    event.registrations.append(registration)
+    db_session.session.add(event)
+    db_session.session.commit()
+
+    response = admin_client.get(
+        f"/admin/events/{event.id}/registrations/data"
+    )
+
+    body = response.get_json()
+    keys = [column["key"] for column in body["columns"]]
+    assert keys.count("competition_gender") == 1
+    assert body["registrations"][0]["competition_gender"] == "Mixed"

--- a/tests/events/test_dry_tri_seed.py
+++ b/tests/events/test_dry_tri_seed.py
@@ -58,8 +58,9 @@ def test_dry_tri_2026_builder_copies_dry_tri_template():
     assert run_only["participant_roles"] == ["Participant"]
     assert all(option["member_price_cents"] is None for option in options)
 
-    assert len(questions) == 5
+    assert len(questions) == 6
     assert [question["required"] for question in questions] == [
+        True,
         True,
         False,
         True,

--- a/tests/events/test_routes.py
+++ b/tests/events/test_routes.py
@@ -99,8 +99,6 @@ def _payload(option, participant_count=None):
     )
     return {
         "price_option_id": option.id,
-        "contact_email": "captain@example.com",
-        "contact_phone": "555-0100",
         "team_name": "Nordic Rockets" if option.participant_count > 1 else "",
         "emergency_contact_name": "Emergency Contact",
         "emergency_contact_phone": "555-0199",
@@ -233,14 +231,14 @@ def test_post_valid_individual_creates_pending_registration_and_intent(
     assert kwargs["amount"] == 5500
     assert kwargs["currency"] == "usd"
     assert kwargs["capture_method"] == "automatic"
-    assert kwargs["receipt_email"] == "captain@example.com"
+    assert kwargs["receipt_email"] == "participant1@example.com"
     assert kwargs["statement_descriptor"].startswith("TCSC_EVENT_")
     assert kwargs["description"] == "TCSC Event - Dry Tri 2026"
     assert kwargs["metadata"] == {
         "payment_type": "event",
         "event_id": str(event.id),
         "registration_id": str(registration.id),
-        "email": "captain@example.com",
+        "email": "participant1@example.com",
         "name": "Participant 1",
     }
     assert kwargs["idempotency_key"] == "event-attempt-123"
@@ -366,3 +364,111 @@ def test_dry_tri_legacy_urls_redirect_to_generic_event_page(client, path):
 
     assert response.status_code == 302
     assert response.headers["Location"] == "/events/dry-tri-2026"
+
+
+def test_get_event_page_drops_the_registration_contact_section(
+    client,
+    public_event,
+):
+    event, _individual, _team, _free = public_event
+
+    page = client.get(f"/events/{event.slug}").get_data(as_text=True)
+
+    assert "Registration contact" not in page
+    assert 'id="contact-email"' not in page
+    assert 'id="contact-phone"' not in page
+    # Emergency contact and team name stay.
+    assert 'id="emergency-contact-name"' in page
+    assert 'id="team-name"' in page
+
+
+def test_get_event_page_puts_team_name_with_participant_details(
+    client,
+    public_event,
+):
+    event, _individual, _team, _free = public_event
+
+    page = client.get(f"/events/{event.slug}").get_data(as_text=True)
+
+    participants_heading = page.index("Participant details")
+    team_name_field = page.index('id="team-name"')
+    emergency_heading = page.index("Emergency contact")
+
+    assert participants_heading < team_name_field < emergency_heading
+
+
+def test_get_event_page_preserves_description_line_breaks(
+    client,
+    db_session,
+    public_event,
+):
+    event, _individual, _team, _free = public_event
+    event.description = "Roll. Ride. Run.\n\n- 7:30 AM Packet pickup"
+    db_session.session.commit()
+
+    page = client.get(f"/events/{event.slug}").get_data(as_text=True)
+
+    assert "white-space: pre-line" in page
+    assert "Roll. Ride. Run.\n\n- 7:30 AM Packet pickup" in page
+
+
+def test_get_event_page_publishes_each_question_scope(
+    client,
+    db_session,
+    public_event,
+):
+    event, _individual, _team, _free = public_event
+    event.custom_questions = [
+        {
+            "key": "course",
+            "label": "Course",
+            "type": "choice",
+            "options": ["Long", "Short"],
+            "required": True,
+            "price_options": ["Individual", "Team of 3"],
+        },
+        {
+            "key": "club",
+            "label": "Club",
+            "type": "text",
+            "required": False,
+        },
+    ]
+    db_session.session.commit()
+
+    page = client.get(f"/events/{event.slug}").get_data(as_text=True)
+
+    # tojson output is markup-safe, so the attribute is single-quoted.
+    assert 'data-question-scope=\'["Individual", "Team of 3"]\'' in page
+    assert "data-question-scope='[]'" in page
+    # Ids are index-based so a key repeated across scopes stays unique.
+    assert 'id="question-0"' in page
+    assert 'id="question-1"' in page
+    # The section wrapper is what the client hides when nothing is in scope.
+    assert 'id="event-questions"' in page
+
+
+def test_post_ignores_a_client_supplied_registration_contact(
+    db_session,
+    client,
+    public_event,
+):
+    event, individual, _team, _free = public_event
+    payload = _payload(individual)
+    payload["contact_email"] = "spoofed@example.com"
+    payload["contact_phone"] = "555-9999"
+
+    with patch("app.routes.events.stripe.PaymentIntent.create") as create:
+        create.return_value = _intent()
+        response = client.post(
+            f"/events/{event.slug}/register",
+            json=payload,
+        )
+
+    assert response.status_code == 200
+    registration = db_session.session.get(
+        EventRegistration,
+        response.get_json()["registrationId"],
+    )
+    assert registration.contact_email == "participant1@example.com"
+    assert registration.contact_phone == "555-0101"

--- a/tests/events/test_service.py
+++ b/tests/events/test_service.py
@@ -15,6 +15,7 @@ from app.events.service import (
     compute_price,
     create_registration,
     expire_stale_pending,
+    questions_for_option,
 )
 
 
@@ -91,8 +92,6 @@ def _payload(option, participant_count=None):
     )
     return {
         "price_option_id": option.id,
-        "contact_email": "  CAPTAIN@Example.COM ",
-        "contact_phone": "555-0100",
         "team_name": "Nordic Rockets" if count > 1 else None,
         "emergency_contact_name": "Emergency Contact",
         "emergency_contact_phone": "555-0199",
@@ -184,7 +183,8 @@ def test_create_registration_happy_path_individual(
     assert saved.status == RegistrationStatus.PENDING_PAYMENT
     assert saved.amount_cents == 4500
     assert saved.discount_applied is True
-    assert saved.contact_email == "captain@example.com"
+    assert saved.contact_email == "person1@example.com"
+    assert saved.contact_phone == "555-0101"
     assert saved.team_name is None
     assert saved.answers == {"course": "Long", "club": "TCSC"}
     assert len(saved.participants) == 1
@@ -274,8 +274,6 @@ def test_create_registration_collects_required_field_errors(
     payload = _payload(individual)
     payload.update(
         {
-            "contact_email": " ",
-            "contact_phone": "",
             "emergency_contact_name": None,
             "emergency_contact_phone": " ",
         }
@@ -287,8 +285,6 @@ def test_create_registration_collects_required_field_errors(
         create_registration(event, payload)
 
     assert {
-        "contact_email",
-        "contact_phone",
         "emergency_contact_name",
         "emergency_contact_phone",
         "participants",
@@ -484,3 +480,175 @@ def test_create_registration_rejects_closed_signup_window(
         create_registration(event, _payload(individual))
 
     assert "event" in exc_info.value.errors
+
+
+def test_contact_details_come_from_the_first_participant(
+    db_session,
+    registration_setup,
+):
+    event, _individual, team = registration_setup
+    payload = _payload(team)
+    payload["contact_email"] = "spoofed@example.com"
+    payload["contact_phone"] = "555-9999"
+
+    registration = create_registration(event, payload)
+    registration_id = registration.id
+    db_session.session.expire_all()
+    saved = db_session.session.get(EventRegistration, registration_id)
+
+    assert saved.contact_email == "person1@example.com"
+    assert saved.contact_phone == "555-0101"
+    assert saved.participants[0].email == "person1@example.com"
+
+
+def test_question_scoped_to_other_options_is_neither_required_nor_stored(
+    registration_setup,
+):
+    event, individual, team = registration_setup
+    event.custom_questions = [
+        {
+            "key": "course",
+            "label": "Course",
+            "type": "choice",
+            "options": ["Long", "Short"],
+            "required": True,
+            "price_options": ["Team of 3"],
+        },
+    ]
+    payload = _payload(individual)
+    payload["answers"] = {"course": "Long"}
+
+    registration = create_registration(event, payload)
+
+    assert registration.answers == {}
+    assert questions_for_option(event, individual) == []
+    assert len(questions_for_option(event, team)) == 1
+
+
+def test_unscoped_question_applies_to_every_option(registration_setup):
+    event, individual, team = registration_setup
+    event.custom_questions = [
+        {
+            "key": "club",
+            "label": "Club",
+            "type": "text",
+            "required": True,
+        },
+    ]
+
+    for option in (individual, team):
+        assert len(questions_for_option(event, option)) == 1
+
+    payload = _payload(individual)
+    payload["answers"] = {}
+
+    with pytest.raises(RegistrationError) as exc_info:
+        create_registration(event, payload)
+
+    assert "answers.club" in exc_info.value.errors
+
+
+def test_scope_naming_no_surviving_option_falls_open_to_applying(
+    registration_setup,
+):
+    event, individual, _team = registration_setup
+    event.custom_questions = [
+        {
+            "key": "club",
+            "label": "Club",
+            "type": "text",
+            "required": True,
+            "price_options": ["Renamed Away"],
+        },
+    ]
+
+    assert len(questions_for_option(event, individual)) == 1
+
+
+def test_scope_is_honoured_when_any_named_option_still_exists(
+    registration_setup,
+):
+    event, individual, team = registration_setup
+    event.custom_questions = [
+        {
+            "key": "club",
+            "label": "Club",
+            "type": "text",
+            "required": True,
+            "price_options": ["Team of 3", "Renamed Away"],
+        },
+    ]
+
+    assert questions_for_option(event, individual) == []
+    assert len(questions_for_option(event, team)) == 1
+
+
+def test_disjoint_scoped_duplicate_keys_ask_one_question_per_option(
+    registration_setup,
+):
+    event, individual, team = registration_setup
+    event.custom_questions = [
+        {
+            "key": "competition_gender",
+            "label": "Competition gender",
+            "type": "choice",
+            "options": ["Men", "Women", "Non-binary"],
+            "required": True,
+            "price_options": ["Individual"],
+        },
+        {
+            "key": "competition_gender",
+            "label": "Competition gender",
+            "type": "choice",
+            "options": ["Men", "Women", "Mixed"],
+            "required": True,
+            "price_options": ["Team of 3"],
+        },
+    ]
+
+    individual_questions = questions_for_option(event, individual)
+    team_questions = questions_for_option(event, team)
+
+    assert [question["options"] for question in individual_questions] == [
+        ["Men", "Women", "Non-binary"]
+    ]
+    assert [question["options"] for question in team_questions] == [
+        ["Men", "Women", "Mixed"]
+    ]
+
+    payload = _payload(team)
+    payload["answers"] = {"competition_gender": "Mixed"}
+    registration = create_registration(event, payload)
+
+    assert registration.answers == {"competition_gender": "Mixed"}
+
+
+def test_individual_option_rejects_the_team_only_gender_answer(
+    registration_setup,
+):
+    event, individual, _team = registration_setup
+    event.custom_questions = [
+        {
+            "key": "competition_gender",
+            "label": "Competition gender",
+            "type": "choice",
+            "options": ["Men", "Women", "Non-binary"],
+            "required": True,
+            "price_options": ["Individual"],
+        },
+        {
+            "key": "competition_gender",
+            "label": "Competition gender",
+            "type": "choice",
+            "options": ["Men", "Women", "Mixed"],
+            "required": True,
+            "price_options": ["Team of 3"],
+        },
+    ]
+    payload = _payload(individual)
+    payload["answers"] = {"competition_gender": "Mixed"}
+
+    with pytest.raises(RegistrationError) as exc_info:
+        create_registration(event, payload)
+
+    assert "answers.competition_gender" in exc_info.value.errors

--- a/tests/events/test_templates.py
+++ b/tests/events/test_templates.py
@@ -64,11 +64,11 @@ def test_apply_template_copies_questions_and_price_options(db_session):
     saved_event = db_session.session.get(Event, event_id)
 
     assert saved_event.template_key == "dry_tri"
-    assert len(saved_event.custom_questions) == 5
+    assert len(saved_event.custom_questions) == 6
     assert saved_event.custom_questions[0]["label"] == "Competition gender"
     assert [option.name for option in saved_event.price_options] == [
-        "Individual",
-        "Team of 3",
+        "Individual Triathlon",
+        "Relay Triathlon",
         "Run-only 6K",
     ]
     assert saved_event.price_options[1].participant_roles == [
@@ -181,3 +181,71 @@ templates:
 def test_apply_template_with_unknown_key_raises_value_error():
     with pytest.raises(ValueError, match=r"Unknown event template 'missing'"):
         event_templates.apply_template(_event(), "missing")
+
+
+def test_dry_tri_template_scopes_questions_by_price_option():
+    template = event_templates.get_template("dry_tri")
+    names = [option["name"] for option in template["price_options"]]
+
+    assert names == [
+        "Individual Triathlon",
+        "Relay Triathlon",
+        "Run-only 6K",
+    ]
+
+    scopes = {}
+    for question in template["custom_questions"]:
+        scopes.setdefault(question["key"], []).append(
+            (question.get("price_options") or [], question.get("options"))
+        )
+
+    # Individual entries can be non-binary; relay teams can be mixed.
+    assert scopes["competition_gender"] == [
+        (
+            ["Individual Triathlon", "Run-only 6K"],
+            ["Men", "Women", "Non-binary"],
+        ),
+        (["Relay Triathlon"], ["Men", "Women", "Mixed"]),
+    ]
+    # Run-only participants are asked neither course nor wave.
+    for key in ("course", "wave"):
+        assert scopes[key][0][0] == [
+            "Individual Triathlon",
+            "Relay Triathlon",
+        ]
+    # Club and city apply to everyone.
+    for key in ("club", "city_state"):
+        assert scopes[key][0][0] == []
+
+    # Every scope must name a real price option.
+    for question in template["custom_questions"]:
+        for name in question.get("price_options") or []:
+            assert name in names
+
+
+def test_question_price_options_must_be_a_list_of_strings(
+    tmp_path,
+    monkeypatch,
+):
+    config_path = tmp_path / "event_templates.yaml"
+    config_path.write_text(
+        """
+templates:
+  broken:
+    name: Broken
+    price_options: []
+    custom_questions:
+      - key: course
+        label: Course
+        type: text
+        required: false
+        price_options: "Individual"
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(event_templates, "_CONFIG_PATH", config_path)
+
+    with pytest.raises(
+        ValueError, match=r"'course'.*'price_options' must be a list of str"
+    ):
+        event_templates.load_event_templates()

--- a/tests/js/admin_event_scopes.test.js
+++ b/tests/js/admin_event_scopes.test.js
@@ -1,0 +1,240 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {JSDOM} = require('jsdom');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SOURCE = fs.readFileSync(
+  path.join(ROOT, 'app/static/admin_events.js'), 'utf8');
+
+const TEMPLATES = {
+  blank: {price_options: [], custom_questions: []},
+  dry_tri: {
+    price_options: [
+      {name: 'Individual Triathlon', description: '', price_cents: 5500,
+       member_price_cents: 3500, participant_roles: ['Participant'],
+       active: true}
+    ],
+    custom_questions: [
+      {key: 'course', label: 'Course', type: 'choice', options: ['Long'],
+       required: true, price_options: ['Individual Triathlon']}
+    ]
+  }
+};
+
+// Mirrors admin/event_form.html: the editor is driven entirely by the two
+// hidden JSON textareas.
+function load(priceRows, questionRows, templateKey = 'blank') {
+  const dom = new JSDOM(`<!doctype html><body>
+    <section id="admin-event-form" data-page="form">
+      <form id="event-editor-form">
+        <select id="template_key">
+          <option value="blank">Blank</option>
+          <option value="dry_tri">Dry Tri</option>
+        </select>
+        <button type="button" id="add-price-option">Add price option</button>
+        <div id="price-option-rows"></div>
+        <textarea name="price_options_json" id="price_options_json"
+          hidden>${JSON.stringify(priceRows)}</textarea>
+        <button type="button" id="add-question">Add question</button>
+        <div id="custom-question-rows"></div>
+        <textarea name="custom_questions_json" id="custom_questions_json"
+          hidden>${JSON.stringify(questionRows)}</textarea>
+      </form>
+    </section>
+    <script type="application/json" id="event-template-data">
+      ${JSON.stringify(TEMPLATES)}
+    </script>
+  </body>`);
+  dom.window.document.getElementById('template_key').value = templateKey;
+
+  new Function('window', 'document', SOURCE)(dom.window, dom.window.document);
+  return dom;
+}
+
+function savedQuestions(dom) {
+  return JSON.parse(
+    dom.window.document.getElementById('custom_questions_json').value
+  );
+}
+
+function scopeBoxes(dom, questionIndex) {
+  const rows = dom.window.document.querySelectorAll(
+    '#custom-question-rows .aef-editor-row'
+  );
+  return Array.from(
+    rows[questionIndex].querySelectorAll('[data-field="scope"]')
+  );
+}
+
+function priceNameInput(dom, index) {
+  const rows = dom.window.document.querySelectorAll(
+    '#price-option-rows .aef-editor-row'
+  );
+  return rows[index].querySelector('[data-field="name"]');
+}
+
+const TWO_OPTIONS = [
+  {id: 1, name: 'Individual Triathlon', description: '', price_cents: 5500,
+   member_price_cents: 3500, participant_roles: ['Participant'], active: true},
+  {id: 2, name: 'Relay Triathlon', description: '', price_cents: 10500,
+   member_price_cents: 7500,
+   participant_roles: ['Rollerskier', 'Mountain Biker', 'Trail Runner'],
+   active: true}
+];
+
+const GENDER_QUESTIONS = [
+  {key: 'competition_gender', label: 'Competition gender', type: 'choice',
+   options: ['Men', 'Women', 'Non-binary'], required: true, help_text: '',
+   price_options: ['Individual Triathlon']},
+  {key: 'competition_gender', label: 'Competition gender', type: 'choice',
+   options: ['Men', 'Women', 'Mixed'], required: true, help_text: '',
+   price_options: ['Relay Triathlon']}
+];
+
+test('each question offers a checkbox per price option', () => {
+  const dom = load(TWO_OPTIONS, GENDER_QUESTIONS);
+
+  const boxes = scopeBoxes(dom, 0);
+  assert.deepEqual(boxes.map(box => box.value),
+    ['Individual Triathlon', 'Relay Triathlon']);
+  assert.deepEqual(boxes.map(box => box.checked), [true, false]);
+  assert.deepEqual(scopeBoxes(dom, 1).map(box => box.checked), [false, true]);
+});
+
+test('checking a box records that option in the saved scope', () => {
+  const dom = load(TWO_OPTIONS, GENDER_QUESTIONS);
+  const box = scopeBoxes(dom, 0)[1];
+
+  box.checked = true;
+  box.dispatchEvent(new dom.window.Event('change', {bubbles: true}));
+
+  assert.deepEqual(savedQuestions(dom)[0].price_options,
+    ['Individual Triathlon', 'Relay Triathlon']);
+});
+
+test('unchecking every box means the question applies to all options', () => {
+  const dom = load(TWO_OPTIONS, GENDER_QUESTIONS);
+  const box = scopeBoxes(dom, 0)[0];
+
+  box.checked = false;
+  box.dispatchEvent(new dom.window.Event('change', {bubbles: true}));
+
+  assert.deepEqual(savedQuestions(dom)[0].price_options, []);
+});
+
+test('renaming a price option carries its question scopes along', () => {
+  const dom = load(TWO_OPTIONS, GENDER_QUESTIONS);
+  const nameInput = priceNameInput(dom, 1);
+
+  nameInput.value = 'Relay Team';
+  nameInput.dispatchEvent(new dom.window.Event('change', {bubbles: true}));
+
+  assert.deepEqual(savedQuestions(dom)[1].price_options, ['Relay Team']);
+  assert.deepEqual(scopeBoxes(dom, 1).map(box => box.value),
+    ['Individual Triathlon', 'Relay Team']);
+  assert.deepEqual(scopeBoxes(dom, 1).map(box => box.checked), [false, true]);
+});
+
+test('removing a price option drops it from every question scope', () => {
+  const dom = load(TWO_OPTIONS, GENDER_QUESTIONS);
+  const rows = dom.window.document.querySelectorAll(
+    '#price-option-rows .aef-editor-row'
+  );
+
+  rows[1].querySelector('.aef-remove').click();
+
+  assert.deepEqual(savedQuestions(dom)[1].price_options, []);
+  assert.deepEqual(scopeBoxes(dom, 0).map(box => box.value),
+    ['Individual Triathlon']);
+});
+
+test('adding a price option offers it to existing questions', () => {
+  const dom = load(TWO_OPTIONS, GENDER_QUESTIONS);
+
+  dom.window.document.getElementById('add-price-option').click();
+
+  // The new row has no name yet, so it is not offered until it is named.
+  assert.deepEqual(scopeBoxes(dom, 0).map(box => box.value),
+    ['Individual Triathlon', 'Relay Triathlon']);
+
+  const nameInput = priceNameInput(dom, 2);
+  nameInput.value = 'Run-only 6K';
+  nameInput.dispatchEvent(new dom.window.Event('change', {bubbles: true}));
+
+  assert.deepEqual(scopeBoxes(dom, 0).map(box => box.value),
+    ['Individual Triathlon', 'Relay Triathlon', 'Run-only 6K']);
+});
+
+test('a question editor with no price options explains what to do', () => {
+  const dom = load([], GENDER_QUESTIONS);
+  const rows = dom.window.document.querySelectorAll(
+    '#custom-question-rows .aef-editor-row'
+  );
+
+  assert.match(rows[0].textContent, /Add a price option first/);
+  assert.equal(scopeBoxes(dom, 0).length, 0);
+});
+
+test('applying a template over existing data asks before replacing it', () => {
+  const dom = load(TWO_OPTIONS, GENDER_QUESTIONS);
+  const select = dom.window.document.getElementById('template_key');
+  const asked = [];
+  dom.window.confirm = message => {
+    asked.push(message);
+    return false;
+  };
+
+  select.value = 'dry_tri';
+  select.dispatchEvent(new dom.window.Event('change', {bubbles: true}));
+
+  assert.equal(asked.length, 1);
+  assert.match(asked[0], /replaces all price options/);
+  // Declining leaves the member prices and the selector untouched.
+  assert.equal(select.value, 'blank');
+  assert.deepEqual(
+    JSON.parse(
+      dom.window.document.getElementById('price_options_json').value
+    ).map(option => option.member_price_cents),
+    [3500, 7500]
+  );
+});
+
+test('confirming the template swap replaces price options and questions', () => {
+  const dom = load(TWO_OPTIONS, GENDER_QUESTIONS);
+  const select = dom.window.document.getElementById('template_key');
+  dom.window.confirm = () => true;
+
+  select.value = 'dry_tri';
+  select.dispatchEvent(new dom.window.Event('change', {bubbles: true}));
+
+  assert.deepEqual(
+    JSON.parse(
+      dom.window.document.getElementById('price_options_json').value
+    ).map(option => option.name),
+    ['Individual Triathlon']
+  );
+  assert.deepEqual(savedQuestions(dom).map(question => question.key),
+    ['course']);
+  assert.equal(select.value, 'dry_tri');
+});
+
+test('an empty editor applies a template without prompting', () => {
+  const dom = load([], []);
+  const select = dom.window.document.getElementById('template_key');
+  let asked = 0;
+  dom.window.confirm = () => {
+    asked += 1;
+    return true;
+  };
+
+  select.value = 'dry_tri';
+  select.dispatchEvent(new dom.window.Event('change', {bubbles: true}));
+
+  assert.equal(asked, 0);
+  assert.deepEqual(savedQuestions(dom).map(question => question.key),
+    ['course']);
+});

--- a/tests/js/event_registration_scopes.test.js
+++ b/tests/js/event_registration_scopes.test.js
@@ -1,0 +1,249 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {JSDOM} = require('jsdom');
+
+const ROOT = path.resolve(__dirname, '../..');
+const SOURCE = fs.readFileSync(
+  path.join(ROOT, 'app/static/event_registration.js'), 'utf8');
+
+const OPTIONS = [
+  {
+    id: 1,
+    name: 'Individual Triathlon',
+    description: 'Solo',
+    priceCents: 0,
+    memberPriceCents: null,
+    participantRoles: ['Participant']
+  },
+  {
+    id: 2,
+    name: 'Relay Triathlon',
+    description: 'Team of three',
+    priceCents: 0,
+    memberPriceCents: null,
+    participantRoles: ['Rollerskier', 'Mountain Biker', 'Trail Runner']
+  },
+  {
+    id: 3,
+    name: 'Run-only 6K',
+    description: 'Just the run',
+    priceCents: 0,
+    memberPriceCents: null,
+    participantRoles: ['Participant']
+  }
+];
+
+// Mirrors the markup events/registration.html emits, including the
+// index-based ids that let one key repeat across scopes.
+function questionMarkup(questions) {
+  return questions.map((question, index) => `
+    <div class="form-field" data-question-field="${index}"
+         data-question-scope='${JSON.stringify(question.scope)}'>
+      <label class="form-field__label" for="question-${index}">
+        ${question.label}
+      </label>
+      <select id="question-${index}" class="form-input"
+              data-question-key="${question.key}"
+              ${question.required ? 'required' : ''}>
+        <option value="">Select an option</option>
+        ${(question.options || []).map(
+          choice => `<option value="${choice}">${choice}</option>`
+        ).join('')}
+      </select>
+    </div>`).join('');
+}
+
+function load(questions, priceOptions = OPTIONS) {
+  const data = {slug: 'dry-tri-2026', priceOptions, customQuestions: []};
+  const dom = new JSDOM(`<!doctype html><body>
+    <script id="event-registration-data" type="application/json">
+      ${JSON.stringify(data)}
+    </script>
+    <form id="event-registration-form" novalidate>
+      <div id="price-options">
+        ${priceOptions.map((option, index) => `
+          <label class="price-option-container">
+            <input type="radio" name="price_option_id" value="${option.id}"
+                   ${index === 0 ? 'checked' : ''} required>
+          </label>`).join('')}
+      </div>
+      <p id="option-description"></p>
+      <div class="form-field hidden" id="team-name-field">
+        <input type="text" id="team-name" class="form-input">
+      </div>
+      <div id="participants-container"></div>
+      <input type="text" id="emergency-contact-name">
+      <input type="tel" id="emergency-contact-phone">
+      <section class="form-section" id="event-questions">
+        <h2 id="event-questions-title">Event questions</h2>
+        ${questionMarkup(questions)}
+      </section>
+      <input type="text" id="discount-code">
+      <div id="card-field"><div id="card-element"></div></div>
+      <div class="card-error" id="form-errors" role="alert"></div>
+      <button id="submit" type="submit">
+        <span class="spinner hidden" id="spinner"></span>
+        <span id="button-text">Continue</span>
+      </button>
+    </form>
+  </body>`);
+
+  new Function('window', 'document', SOURCE)(dom.window, dom.window.document);
+  return dom;
+}
+
+function select(dom, optionId) {
+  const radio = dom.window.document.querySelector(
+    `input[name="price_option_id"][value="${optionId}"]`
+  );
+  radio.checked = true;
+  radio.dispatchEvent(new dom.window.Event('change', {bubbles: true}));
+}
+
+function stateOf(dom, index) {
+  const document = dom.window.document;
+  const field = document.querySelector(`[data-question-field="${index}"]`);
+  const input = document.getElementById(`question-${index}`);
+  return {hidden: field.classList.contains('hidden'), disabled: input.disabled};
+}
+
+const DRY_TRI_QUESTIONS = [
+  {
+    key: 'competition_gender',
+    label: 'Competition gender',
+    options: ['Men', 'Women', 'Non-binary'],
+    required: true,
+    scope: ['Individual Triathlon', 'Run-only 6K']
+  },
+  {
+    key: 'competition_gender',
+    label: 'Competition gender',
+    options: ['Men', 'Women', 'Mixed'],
+    required: true,
+    scope: ['Relay Triathlon']
+  },
+  {
+    key: 'course',
+    label: 'Course',
+    options: ['Long', 'Short'],
+    required: true,
+    scope: ['Individual Triathlon', 'Relay Triathlon']
+  },
+  {key: 'club', label: 'Club', options: ['TCSC'], required: false, scope: []}
+];
+
+test('individual entry gets the non-binary gender question only', () => {
+  const dom = load(DRY_TRI_QUESTIONS);
+
+  assert.deepEqual(stateOf(dom, 0), {hidden: false, disabled: false});
+  assert.deepEqual(stateOf(dom, 1), {hidden: true, disabled: true});
+});
+
+test('relay entry gets the mixed gender question only', () => {
+  const dom = load(DRY_TRI_QUESTIONS);
+  select(dom, 2);
+
+  assert.deepEqual(stateOf(dom, 0), {hidden: true, disabled: true});
+  assert.deepEqual(stateOf(dom, 1), {hidden: false, disabled: false});
+});
+
+test('run-only entry is asked neither course nor a mixed gender', () => {
+  const dom = load(DRY_TRI_QUESTIONS);
+  select(dom, 3);
+
+  assert.deepEqual(stateOf(dom, 0), {hidden: false, disabled: false});
+  assert.deepEqual(stateOf(dom, 1), {hidden: true, disabled: true});
+  assert.deepEqual(stateOf(dom, 2), {hidden: true, disabled: true});
+});
+
+test('an unscoped question applies to every entry option', () => {
+  const dom = load(DRY_TRI_QUESTIONS);
+
+  for (const optionId of [1, 2, 3]) {
+    select(dom, optionId);
+    assert.deepEqual(stateOf(dom, 3), {hidden: false, disabled: false});
+  }
+});
+
+test('a scope naming no surviving option falls open to applying', () => {
+  const dom = load([
+    {key: 'club', label: 'Club', options: ['TCSC'], required: false,
+     scope: ['Renamed Away']}
+  ]);
+
+  assert.deepEqual(stateOf(dom, 0), {hidden: false, disabled: false});
+});
+
+test('a scope is honoured while any named option still exists', () => {
+  const dom = load([
+    {key: 'club', label: 'Club', options: ['TCSC'], required: false,
+     scope: ['Relay Triathlon', 'Renamed Away']}
+  ]);
+
+  assert.deepEqual(stateOf(dom, 0), {hidden: true, disabled: true});
+  select(dom, 2);
+  assert.deepEqual(stateOf(dom, 0), {hidden: false, disabled: false});
+});
+
+test('malformed scope data applies the question rather than dropping it', () => {
+  const dom = load([
+    {key: 'club', label: 'Club', options: ['TCSC'], required: false, scope: []}
+  ]);
+  const field = dom.window.document.querySelector('[data-question-field="0"]');
+  field.dataset.questionScope = 'not json';
+  select(dom, 2);
+
+  assert.deepEqual(stateOf(dom, 0), {hidden: false, disabled: false});
+});
+
+test('an out-of-scope answer already typed is kept but not submitted', () => {
+  const dom = load(DRY_TRI_QUESTIONS);
+  const document = dom.window.document;
+
+  document.getElementById('question-2').value = 'Long';
+  select(dom, 3);
+
+  // Preserved in the DOM for a switch back, but excluded from the payload.
+  assert.equal(document.getElementById('question-2').value, 'Long');
+  const submitted = Array.from(
+    document.querySelectorAll('[data-question-key]:not([disabled])')
+  ).map(input => input.dataset.questionKey);
+  assert.deepEqual(submitted, ['competition_gender', 'club']);
+
+  select(dom, 1);
+  assert.equal(document.getElementById('question-2').value, 'Long');
+  assert.equal(document.getElementById('question-2').disabled, false);
+});
+
+test('team name is required and enabled only for a multi-role option', () => {
+  const dom = load(DRY_TRI_QUESTIONS);
+  const document = dom.window.document;
+  const field = document.getElementById('team-name-field');
+  const input = document.getElementById('team-name');
+
+  assert.equal(field.classList.contains('hidden'), true);
+  assert.equal(input.required, false);
+  assert.equal(input.disabled, true);
+
+  select(dom, 2);
+  assert.equal(field.classList.contains('hidden'), false);
+  assert.equal(input.required, true);
+  assert.equal(input.disabled, false);
+});
+
+test('the questions section hides when nothing is in scope', () => {
+  const dom = load([
+    {key: 'course', label: 'Course', options: ['Long'], required: true,
+     scope: ['Relay Triathlon']}
+  ]);
+  const section = dom.window.document.getElementById('event-questions');
+
+  assert.equal(section.classList.contains('hidden'), true);
+
+  select(dom, 2);
+  assert.equal(section.classList.contains('hidden'), false);
+});

--- a/tests/test_events_js.py
+++ b/tests/test_events_js.py
@@ -1,0 +1,22 @@
+"""Run the events registration JavaScript suite from pytest.
+
+Mirrors tests/practices/test_practice_plan_reaction_js.py so the jsdom
+coverage for per-option question scoping runs with the Python suite.
+"""
+
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_events_javascript_suite():
+    result = subprocess.run(
+        ["npm", "run", "test:events"],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Fix pass on the Dry Tri 2026 draft from the events organizer's feedback. No migration; the live event's questions are updated in the admin after deploy.

## Feedback addressed

| Feedback | Change |
|---|---|
| Line spacing on the edit screen doesn't carry to the webpage | `white-space: pre-line` on the description; the stored text already had the breaks |
| Don't collect registration contact info — participant info is sufficient | Section removed; contact derives from participant 1 |
| Teams should choose a team name in their participant information | Team name moved in with participant details, relay-only |
| Additional questions should differ by which event is chosen | Optional `price_options` scope per question, editable in the admin |
| Individual: non-binary option, no mixed | Scoped gender question |
| Team: mixed option, no non-binary | Scoped gender question |
| Run-only shouldn't be asked course or wave | Both scoped away from Run-only 6K |
| "I added discount code information, does it look correct" | Verified against prod: `TCSC2026` with member prices on all three options, and `compute_price` fires for each |

## How scoping works

Each question gains an optional `price_options` list of option names. Absent or empty still means every option, so existing questions keep their behaviour with no data change.

- **Public form** hides *and disables* out-of-scope inputs, so they leave both browser validation and the payload. Disabling rather than removing preserves a typed answer if the registrant switches options and back.
- **Server** filters questions by the chosen option before validating, so a client cannot smuggle in an answer to a question its option was never asked.
- **Unresolvable scopes fail open to shown**, matching the codebase convention — a required question appearing when it needn't is benign; silently dropping one is not.
- **A key may repeat** when the scopes sharing it are pairwise disjoint, so one logical question with per-option answer sets occupies a single roster column. Overlapping or unscoped duplicates raise, admin save rejects a scope naming a nonexistent option, and roster columns dedupe by key.

## Dropping the registration contact

`contact_email` / `contact_phone` are `NOT NULL` and feed the Stripe `receipt_email`, the roster, and the CSV export. Rather than migrate them nullable, the server derives them from participant 1 and ignores any client-supplied value. Consequence to accept: a relay team's receipt goes to whoever is entered first.

## Two bugs caught while building

- Flask's `tojson` is markup-safe, so the scope attribute's double quotes went unescaped and broke the HTML — scoping would have silently done nothing in the browser. The attribute is single-quoted now (`tojson` escapes `'` for exactly this), and a rendering test pins it.
- The admin template dropdown replaces price options wholesale. Before this PR that would have wiped the Dry Tri member prices and quietly stopped `TCSC2026` from discounting anything, so it now asks for confirmation. The `dry_tri` template itself is updated to match production field for field, which makes re-applying it the fast path for fixing the live event.

## Testing

1559 passing (was 1553), including jsdom suites that drive the real registration form and the real admin question editor:

- `tests/js/event_registration_scopes.test.js` — per-option toggling, fail-open, preserved-but-not-submitted answers, empty-section hiding
- `tests/js/admin_event_scopes.test.js` — scope checkboxes, scopes following an option rename or removal, template-swap confirmation
- Python: derived contact, scope filtering, disjoint-key rules, roster column dedupe, rendered-page assertions

`tests/wix_scrape` can't collect in this environment (`PIL`/`playwright` not installed) — pre-existing and unrelated.

## After deploy

`docs/superpowers/notes/2026-07-28-dry-tri-question-scoping-admin-steps.md` — the live event keeps its own copy of the questions JSON, so re-apply the `dry_tri` template in the admin. Must happen while Dry Tri still has zero registrations, since replacing price options is blocked once any exist.

Separately flagged, not changed: `TCSC2026` is a single guessable string with no membership check or usage cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)