### PR TITLE
Admin UI polish 2/6: payments

### DIFF
--- a/app/templates/admin/payments.html
+++ b/app/templates/admin/payments.html
@@ -488,6 +488,7 @@
   #pay-root .pw-row-item {
     flex-direction: column;
     padding: 10px 12px;
+    gap: 0;
   }
   #pay-root .pw-row-item > .pw-row-check {
     /* keep checkbox at top-left in column layout */


### PR DESCRIPTION
## Admin UI polish 2/6 — payments

One-line change, and the Codex review returned **CLEAN** on it: narrowly scoped, correct in both admin variants.

### The defect

The payments row switches to `flex-direction: column` at mobile, but the `gap: 12px` set for the desktop horizontal layout was never overridden. That left ~20-25px of dead space between the checkbox and the name/email block on every row card.

### Why it needed care

This surface has **two structurally different variants**, not just a text difference:
- `admin_payments.js` sets `hidden` on the bulk-bar sum element when `can_view_amounts` is false, so that bar has one child fewer
- `payments.html` gives `.pw-row-amount` `min-width:72px` at desktop but `min-width:0` at mobile, so em-dash rows are narrower

Only two email addresses are on `FINANCE_AUTHORIZED_EMAILS`, so most real admins see the non-finance variant. Verified in both.

### Verification

Measured `document.scrollWidth` at 360/375/390/1024/1440px — no overflow at any width. 30 screenshots across both variants. Tests: 1594 pytest, 81 + 20 JS.

Fixes finding #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
