### PR TITLE
build: compile Tailwind at deploy instead of shipping a committed artifact

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -63,7 +63,14 @@ projects:
               - key: ANTHROPIC_API_KEY
                 sync: false
             region: oregon
-            buildCommand: pip install -r requirements.txt
+            # Tailwind must be built here, not committed. Production serves
+            # app/static/css/tailwind-output.css, and when that file was only
+            # ever generated locally, any new utility class in a template was a
+            # silent no-op in production -- the CSS rule simply did not exist.
+            # It also conflicted on every concurrent branch, and the only safe
+            # resolution was a rebuild, since taking either side dropped the
+            # other branch's classes.
+            buildCommand: pip install -r requirements.txt && npm ci && npm run tailwind:build
             startCommand: gunicorn "app:create_app()"
             preDeployCommand: ./scripts/release.sh
             domains:


### PR DESCRIPTION
## Compile Tailwind at deploy instead of shipping a committed artifact

Found while doing the admin spacing polish. Independent of that work and safe to merge on its own.

### The problem

Production serves `app/static/css/tailwind-output.css`. The app service's build command was `pip install -r requirements.txt`, and `release.sh` has no Tailwind step — so the **committed** artifact was the only thing that ever reached production, and it was only ever regenerated by hand.

Two consequences, both hit during the polish work:

**1. Any new utility class in a template was a silent no-op in production.** The CSS rule simply didn't exist in the served file. Verified against the live stylesheet:

```
sm:px-6     0 matches in production CSS
sm:w-auto   0 matches
sm:gap-4    0 matches
lg:py-0     0 matches
```

All four rendered correctly against a local rebuild. Every screenshot I used to verify those fixes was taken against a stylesheet production would never have served. It fails silently — the page renders, the fix just does nothing.

**2. A 37KB generated file conflicts on every concurrent branch.** It conflicted three times while merging five branches, and the only safe resolution is a rebuild — taking either side silently drops the other branch's classes.

### The change

One line: `pip install -r requirements.txt && npm ci && npm run tailwind:build`

`package-lock.json` is committed and `npm ci` resolves cleanly.

### Risk, stated plainly

I can't verify from here that Node is available in this service's runtime. Render's Python runtime generally includes it, and the repo's static site service already uses npm, but that's a different service and not proof.

If Node is missing, **the build fails loudly** and this is a one-line revert. That's why the committed artifact is deliberately **retained** rather than gitignored: a failed build with a stale fallback still serves a working admin UI, while a failed build with no fallback serves one with no CSS at all.

Suggested sequencing: merge this, watch one deploy succeed, then remove the committed artifact in a follow-up. That's when the merge-conflict problem fully goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
