### PR TITLE
Fix: CTA strip linked at its own section in production

### DIFF
--- a/site/scripts/test-build.mjs
+++ b/site/scripts/test-build.mjs
@@ -40,7 +40,17 @@ const { port } = server.address();
 
 const build = spawn('npx', ['astro', 'build', '--force'], {
   stdio: 'inherit',
-  env: { ...process.env, PUBLIC_SEASON_API_URL: `http://127.0.0.1:${port}/api/season` },
+  // TCSC_EDGE_CONFIG mirrors render.yaml's setting for tcsc-team-site. It
+  // switches Astro to build.format 'file' and trailingSlash 'never', which
+  // changes each page's own url -- and therefore anything comparing against
+  // it. Building without it once let a same-page-anchor guard pass every
+  // local check and still regress in production, so the test build uses the
+  // production configuration.
+  env: {
+    ...process.env,
+    TCSC_EDGE_CONFIG: 'true',
+    PUBLIC_SEASON_API_URL: `http://127.0.0.1:${port}/api/season`,
+  },
 });
 
 build.on('exit', (code) => {

--- a/site/src/lib/samePageAnchor.ts
+++ b/site/src/lib/samePageAnchor.ts
@@ -32,6 +32,12 @@ export function isSamePageAnchor(
   if (!link.hash) return false;
   if (link.origin !== page.origin) return false;
 
-  const path = (url: URL) => url.pathname.replace(/\/+$/, '');
+  // Normalise an explicit index file away before comparing. Production builds
+  // with TCSC_EDGE_CONFIG=true, which sets Astro's build.format to 'file' and
+  // trailingSlash to 'never', so the home page's own url is /index.html while
+  // the authored anchor is /#registration. Comparing those raw made this
+  // return false in production only -- the guard silently stopped firing and
+  // the CTA strip went back to linking at its own section.
+  const path = (url: URL) => url.pathname.replace(/\/index\.html?$/i, '').replace(/\/+$/, '');
   return path(link) === path(page);
 }

--- a/site/tests/contentRefinements.test.mjs
+++ b/site/tests/contentRefinements.test.mjs
@@ -2,6 +2,22 @@ import assert from 'node:assert/strict';
 import { readdirSync, readFileSync } from 'node:fs';
 import test from 'node:test';
 
+// Astro emits dist/<slug>/index.html with build.format 'directory' and
+// dist/<slug>.html with 'file'. Production sets TCSC_EDGE_CONFIG=true, which
+// selects 'file', and the test build now matches it -- so resolve either.
+function page(slug) {
+  const base = new URL('../dist/', import.meta.url);
+  for (const candidate of [`${slug}/index.html`, `${slug}.html`]) {
+    try {
+      return readFileSync(new URL(candidate, base), 'utf8');
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  }
+  throw new Error(`no built page for ${slug} (tried both build formats)`);
+}
+
+
 const source = {
   home: readFileSync(new URL('../src/content/pages/home.yaml', import.meta.url), 'utf8'),
   ctaStrip: readFileSync(new URL('../src/components/CTAStrip.astro', import.meta.url), 'utf8'),
@@ -21,14 +37,11 @@ const source = {
 
 const html = {
   home: readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8'),
-  dryTri: readFileSync(new URL('../dist/dry-tri/index.html', import.meta.url), 'utf8'),
-  extraTraining: readFileSync(
-    new URL('../dist/extra-training-fun/index.html', import.meta.url),
-    'utf8',
-  ),
-  community: readFileSync(new URL('../dist/community/index.html', import.meta.url), 'utf8'),
-  racing: readFileSync(new URL('../dist/racing/index.html', import.meta.url), 'utf8'),
-  sponsors: readFileSync(new URL('../dist/sponsors/index.html', import.meta.url), 'utf8'),
+  dryTri: page('dry-tri'),
+  extraTraining: page('extra-training-fun'),
+  community: page('community'),
+  racing: page('racing'),
+  sponsors: page('sponsors'),
 };
 
 const MISSION =

--- a/site/tests/contentRollback.test.mjs
+++ b/site/tests/contentRollback.test.mjs
@@ -4,6 +4,22 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
+// Astro emits dist/<slug>/index.html with build.format 'directory' and
+// dist/<slug>.html with 'file'. Production sets TCSC_EDGE_CONFIG=true, which
+// selects 'file', and the test build now matches it -- so resolve either.
+function page(slug) {
+  const base = new URL('../dist/', import.meta.url);
+  for (const candidate of [`${slug}/index.html`, `${slug}.html`]) {
+    try {
+      return readFileSync(new URL(candidate, base), 'utf8');
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  }
+  throw new Error(`no built page for ${slug} (tried both build formats)`);
+}
+
+
 const title = 'Stone Grind or Hotbox? When Skis Need a Second Wind';
 const route = '/wax-room/stone-grind-or-hotbox';
 const sourceUrl = new URL(
@@ -31,6 +47,6 @@ test('keeps the withdrawn Wax Room article unpublished', () => {
     'home page must hide the Wax Room section while it has no published entries',
   );
 
-  const indexHtml = readFileSync(new URL('../dist/wax-room/index.html', import.meta.url), 'utf8');
+  const indexHtml = page('wax-room');
   assert.ok(indexHtml.includes('No entries yet.'), 'Wax Room index must retain its empty state');
 });

--- a/site/tests/registrationCta.test.mjs
+++ b/site/tests/registrationCta.test.mjs
@@ -67,6 +67,23 @@ test('does not treat off-page destinations as same-page anchors', () => {
   assert.equal(isSamePageAnchor('not a url', HOME), false);
 });
 
+test('matches when the page url is an explicit index file', () => {
+  // Production builds with TCSC_EDGE_CONFIG=true, so Astro's build.format is
+  // 'file' and the home page's own url is /index.html rather than /. Before
+  // this normalisation the guard returned false in production only, and the
+  // CTA strip went back to linking at its own section.
+  assert.equal(
+    isSamePageAnchor('https://twincitiesskiclub.org/#registration',
+      'https://twincitiesskiclub.org/index.html'),
+    true,
+  );
+  assert.equal(
+    isSamePageAnchor('/trips#registration',
+      'https://twincitiesskiclub.org/index.html'),
+    false,
+  );
+});
+
 test('ignores a trailing-slash mismatch between link and page', () => {
   assert.equal(
     isSamePageAnchor('https://twincitiesskiclub.org#registration', HOME),

--- a/site/tests/sponsorWallBuild.test.mjs
+++ b/site/tests/sponsorWallBuild.test.mjs
@@ -2,9 +2,25 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+// Astro emits dist/<slug>/index.html with build.format 'directory' and
+// dist/<slug>.html with 'file'. Production sets TCSC_EDGE_CONFIG=true, which
+// selects 'file', and the test build now matches it -- so resolve either.
+function page(slug) {
+  const base = new URL('../dist/', import.meta.url);
+  for (const candidate of [`${slug}/index.html`, `${slug}.html`]) {
+    try {
+      return readFileSync(new URL(candidate, base), 'utf8');
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  }
+  throw new Error(`no built page for ${slug} (tried both build formats)`);
+}
+
+
 const TIER_LABELS = ['Trailblazer Partners', 'Community Partners', 'Supporters'];
 
-const sponsorsHtml = readFileSync(new URL('../dist/sponsors/index.html', import.meta.url), 'utf8');
+const sponsorsHtml = page('sponsors');
 const homeHtml = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
 
 function elementContaining(html, openingTag, marker) {

--- a/site/tests/sponsors-page.test.mjs
+++ b/site/tests/sponsors-page.test.mjs
@@ -2,7 +2,23 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-const sponsorsHtml = readFileSync(new URL('../dist/sponsors/index.html', import.meta.url), 'utf8');
+// Astro emits dist/<slug>/index.html with build.format 'directory' and
+// dist/<slug>.html with 'file'. Production sets TCSC_EDGE_CONFIG=true, which
+// selects 'file', and the test build now matches it -- so resolve either.
+function page(slug) {
+  const base = new URL('../dist/', import.meta.url);
+  for (const candidate of [`${slug}/index.html`, `${slug}.html`]) {
+    try {
+      return readFileSync(new URL(candidate, base), 'utf8');
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+  }
+  throw new Error(`no built page for ${slug} (tried both build formats)`);
+}
+
+
+const sponsorsHtml = page('sponsors');
 const homeHtml = readFileSync(new URL('../dist/index.html', import.meta.url), 'utf8');
 
 const decodeHtml = (text) =>


### PR DESCRIPTION
## The bug

After #233 the bottom CTA strip shipped as:

```html
<a href="https://twincitiesskiclub.org/#registration">Fall registration dates</a>
```

inside `<section id="registration">` — a link to the section it already occupies. That is the exact dead click #233 set out to fix, live on the marketing site.

## Root cause

`render.yaml` sets `TCSC_EDGE_CONFIG=true` for `tcsc-team-site`, which switches Astro to `build.format: 'file'` and `trailingSlash: 'never'`. The home page's own url is then `/index.html`, while the authored anchor is `/#registration`. `isSamePageAnchor` compared `/index.html` against `` and returned false, so the guard silently stopped firing — **in production only**.

Every local check passed because the test build did not set that flag. The suite was never building the way production builds, so a production-only divergence could pass every gate.

## Fixes

- `samePageAnchor.ts` normalises an explicit index file away before comparing paths, so `/index.html` and `/` are the same page.
- `scripts/test-build.mjs` sets `TCSC_EDGE_CONFIG=true`, so the test suite now builds in the production configuration. This is the fix that matters: it closes the class, not just the instance.

Aligning the test build immediately exposed six pre-existing tests that hardcoded `dist/<slug>/index.html` and so had never run against production's output shape either. They now resolve either format.

## Verified under the production configuration

With `TCSC_EDGE_CONFIG=true`, the strip renders `href="https://tcsc.ski/"` labelled "How to register" — honest label and destination together.

- `test:refinement` 62/62, `test:sponsors` 24/24, `test:fallback` 1/1, `astro check` clean.
- A new unit test pins the `/index.html` case directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)