### PR TITLE
Show the registration dates in the hero instead of burying them

### DIFF
--- a/site/src/components/HeroHome.astro
+++ b/site/src/components/HeroHome.astro
@@ -3,6 +3,7 @@ import { Picture } from 'astro:assets';
 import CtaForState from '@/components/CtaForState.astro';
 import { FULL_BLEED } from '@/components/imageWidths';
 import type { RegistrationWindows } from '@/lib/registrationState';
+import { datesLine } from '@/lib/registrationCopy';
 
 interface Props {
   headline: string;
@@ -23,6 +24,20 @@ const props = Astro.props;
 // Widths are passed straight through: Astro's image service clamps each
 // requested width to the source's intrinsic width and appends the intrinsic
 // width itself as a candidate, so it never upscales (see imageWidths.ts).
+
+// The dates line only ever has something to say while coming_soon (open has
+// no upcoming dates worth announcing; closed with no season data has none to
+// show at all). It still bakes all three variants -- like CtaForState does --
+// so registrationFlip.ts can hide it the moment the browser re-derives a
+// later state, rather than leaving stale dates showing under an "open" CTA.
+const dates = datesLine(props.windows ?? {});
+const showDates = props.state === 'coming_soon' && Boolean(dates);
+const datesBaked = {
+  'data-registration-dates': '',
+  'data-open-dates': '',
+  'data-soon-dates': dates ?? '',
+  'data-closed-dates': '',
+};
 ---
 <section class="relative bg-navy overflow-hidden">
   <div class="hero-frame relative">
@@ -55,6 +70,7 @@ const props = Astro.props;
           label_coming_soon={props.cta_coming_soon_label} url_coming_soon={props.cta_coming_soon_url}
           label_closed={props.cta_closed_label} url_closed={props.cta_closed_url}
         />
+        <p class="mt-3 text-xs md:text-sm text-paper/60" {...datesBaked} hidden={!showDates}>{showDates ? dates : ''}</p>
       </div>
     </div>
   </div>

--- a/site/src/components/registrationFlip.ts
+++ b/site/src/components/registrationFlip.ts
@@ -24,6 +24,12 @@ const SUBHEAD_ATTR: Record<Variant, string> = {
   closed: 'data-closed-subhead',
 };
 
+const DATES_ATTR: Record<Variant, string> = {
+  open: 'data-open-dates',
+  coming_soon: 'data-soon-dates',
+  closed: 'data-closed-dates',
+};
+
 function orNull(value: string | null): string | null {
   return value ? value : null;
 }
@@ -63,5 +69,22 @@ for (const element of document.querySelectorAll<HTMLElement>('[data-registration
   if (subhead) {
     const nextSubhead = subhead.getAttribute(SUBHEAD_ATTR[actual]);
     if (nextSubhead) subhead.textContent = nextSubhead;
+  }
+
+  // The hero's dates line lives beside its CTA the same way the strip's
+  // subhead does. Unlike the subhead, it has content in exactly one state
+  // (coming_soon), so an empty baked value means "hide it" rather than
+  // "leave the previous text alone" -- otherwise dates baked under
+  // coming_soon would keep showing under an "open" CTA.
+  const dates = element.closest('section')?.querySelector<HTMLElement>('[data-registration-dates]');
+  if (dates) {
+    const nextDates = dates.getAttribute(DATES_ATTR[actual]);
+    if (nextDates) {
+      dates.textContent = nextDates;
+      dates.hidden = false;
+    } else {
+      dates.hidden = true;
+      dates.textContent = '';
+    }
   }
 }

--- a/site/src/lib/registrationCopy.ts
+++ b/site/src/lib/registrationCopy.ts
@@ -38,6 +38,21 @@ export function datesSentence(w: RegistrationWindows): string | null {
   return parts.length ? parts.join('; ') : null;
 }
 
+/**
+ * "Returning members Aug 28 · New members Sep 3" — null when no dates.
+ *
+ * Standalone display line (hero, under the CTA button): each clause reads on
+ * its own rather than as a sentence fragment, so both start with a capital
+ * and a middle dot separates them instead of a semicolon.
+ */
+export function datesLine(w: RegistrationWindows): string | null {
+  const { returning, fresh } = openingDays(w);
+  const parts: string[] = [];
+  if (returning) parts.push(`Returning members ${returning}`);
+  if (fresh) parts.push(`New members ${fresh}`);
+  return parts.length ? parts.join(' · ') : null;
+}
+
 export function stripSubhead(state: RegistrationState, w: RegistrationWindows): string {
   if (state === 'open') return ABILITY;
   if (state === 'closed') return `Registration is closed. ${ABILITY}`;

--- a/site/tests/seasonBuild.test.mjs
+++ b/site/tests/seasonBuild.test.mjs
@@ -43,6 +43,26 @@ test('a CTA renders the variant matching the baked state', () => {
   assert.equal(cta.textContent.trim(), cta.getAttribute(expected));
 });
 
+test('the hero shows the coming_soon dates line under the CTA, with all baked variants', () => {
+  // The fixture build (scripts/test-build.mjs) always lands on coming_soon
+  // with real windows, so the hero's dates line should be visible and read
+  // the same dates the CTA itself was baked with.
+  const dates = document.querySelector('[data-registration-dates]');
+  assert.ok(dates, 'expected a dates element in the hero section');
+  assert.equal(dates.hasAttribute('hidden'), false, 'dates line should be visible under coming_soon');
+  assert.match(dates.textContent, /Returning members .+ · New members .+/);
+
+  // Baked so registrationFlip.ts can hide it (open/closed) or restore it
+  // (coming_soon) without a rebuild, exactly like the CTA's own variants.
+  assert.equal(dates.getAttribute('data-open-dates'), '');
+  assert.equal(dates.getAttribute('data-closed-dates'), '');
+  assert.equal(dates.getAttribute('data-soon-dates'), dates.textContent);
+
+  const hero = dates.closest('section');
+  const cta = hero.querySelector('[data-registration]');
+  assert.equal(cta.getAttribute('data-state'), 'coming_soon');
+});
+
 test('the registration strip still never links to its own section', () => {
   // Guards the fix from earlier on this branch against the rewrite.
   const strip = document.querySelector('#registration');


### PR DESCRIPTION
## Why

While registration is `coming_soon`, the hero and nav CTA read "Fall registration dates" and their only action was to scroll the visitor to the very bottom of a long page, where a strip finally told them the dates. Clicking a button labelled with information and being dumped at the footer is a poor trade.

## The change

The dates now appear in the hero, directly under the CTA — visible immediately, no click required:

```html
<p class="mt-3 text-xs md:text-sm text-paper/60" data-registration-dates
   data-soon-dates="Returning members Aug 28 · New members Sep 3">
  Returning members Aug 28 · New members Sep 3
</p>
```

Understated by design: small, `text-paper/60`, clearly secondary to the button rather than competing with the headline.

## It stays correct on its own

The line participates in the same flip mechanism as every other CTA — all three states are baked as `data-*` attributes and `registrationFlip.ts` swaps them, so it updates at the exact minute registration opens without a rebuild. In `open` and `closed` it renders `hidden` with empty text, so there is no stray gap. Dates come from `registrationCopy.ts` in US Central; no new date logic was written, and nothing is ever hardcoded — if the API is unreachable the state is `closed` and the line simply does not show.

## Verified

- `test:refinement` 63/63, `test:sponsors` 24/24, `test:fallback` 1/1, `astro check` clean.
- Built under production's configuration (`TCSC_EDGE_CONFIG=true`) in all three states: `coming_soon` renders the dates, `open` and `closed` render `hidden` and empty.
- The bottom strip still falls through to `https://tcsc.ski/` labelled "How to register" rather than linking at its own `#registration` section, and its regression test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)