### PR TITLE
Hide event member pricing until a code is verified

### DIFF
--- a/app/events/service.py
+++ b/app/events/service.py
@@ -24,12 +24,8 @@ class RegistrationError(Exception):
         super().__init__("Event registration validation failed")
 
 
-def compute_price(
-    option: EventPriceOption,
-    event: Event,
-    discount_code: str | None,
-) -> tuple[int, bool]:
-    """Return the server-computed price and whether a discount was applied."""
+def discount_code_matches(event: Event, discount_code: str | None) -> bool:
+    """Return whether ``discount_code`` is the event's configured code."""
     configured_code = (
         event.discount_code.strip().casefold()
         if isinstance(event.discount_code, str)
@@ -40,11 +36,19 @@ def compute_price(
         if isinstance(discount_code, str)
         else ""
     )
-    discount_matches = (
-        bool(configured_code)
-        and configured_code == submitted_code
-    )
-    if discount_matches and option.member_price_cents is not None:
+    return bool(configured_code) and configured_code == submitted_code
+
+
+def compute_price(
+    option: EventPriceOption,
+    event: Event,
+    discount_code: str | None,
+) -> tuple[int, bool]:
+    """Return the server-computed price and whether a discount was applied."""
+    if (
+        discount_code_matches(event, discount_code)
+        and option.member_price_cents is not None
+    ):
         return option.member_price_cents, True
     return option.price_cents, False
 

--- a/app/routes/events.py
+++ b/app/routes/events.py
@@ -1,6 +1,6 @@
 """Public pages and registration checkout for generic events."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from flask import Blueprint, abort, jsonify, render_template, request, session
 import stripe
@@ -12,7 +12,9 @@ from ..events.models import Event, EventStatus, RegistrationStatus
 from ..events.service import (
     RegistrationError,
     capacity_available,
+    compute_price,
     create_registration,
+    discount_code_matches,
     expire_stale_pending,
 )
 from ..models import db
@@ -21,10 +23,35 @@ from .payments import build_statement_descriptor, stripe_idempotency_options
 
 events = Blueprint("events", __name__)
 
+# The discount check answers "is this a real code?", so throttle guessing.
+# Keyed by client rather than session because a signed-cookie counter is
+# bypassed by discarding the cookie. Per-process, so the effective ceiling is
+# this limit times the gunicorn worker count.
+DISCOUNT_ATTEMPT_LIMIT = 10
+DISCOUNT_ATTEMPT_WINDOW = timedelta(minutes=15)
+_discount_attempts: dict[str, list[datetime]] = {}
+
 
 def _is_admin_session():
     user = session.get("user", {})
     return is_allowed_domain(user.get("email"))
+
+
+def _discount_attempts_exhausted(event_id):
+    """Record this check and report whether the client is over the limit."""
+    now = datetime.utcnow()
+    cutoff = now - DISCOUNT_ATTEMPT_WINDOW
+    for key, stamps in list(_discount_attempts.items()):
+        fresh = [stamp for stamp in stamps if stamp > cutoff]
+        if fresh:
+            _discount_attempts[key] = fresh
+        else:
+            del _discount_attempts[key]
+
+    key = f"{request.remote_addr}:{event_id}"
+    attempts = _discount_attempts.setdefault(key, [])
+    attempts.append(now)
+    return len(attempts) > DISCOUNT_ATTEMPT_LIMIT
 
 
 def _event_registration_data(event, price_options):
@@ -36,7 +63,6 @@ def _event_registration_data(event, price_options):
                 "name": option.name,
                 "description": option.description or "",
                 "priceCents": option.price_cents,
-                "memberPriceCents": option.member_price_cents,
                 "participantRoles": (
                     option.participant_roles or ["Participant"]
                 ),
@@ -85,6 +111,45 @@ def get_event_page(slug):
         registration_open=registration_open,
         registration_message=registration_message,
         registration_data=_event_registration_data(event, price_options),
+    )
+
+
+@events.post("/events/<slug>/discount")
+def check_event_discount(slug):
+    """Report the prices a code unlocks without ever publishing the code."""
+    event = Event.query.filter_by(slug=slug).first_or_404()
+    draft_preview = (
+        event.status == EventStatus.DRAFT and _is_admin_session()
+    )
+    if event.status != EventStatus.ACTIVE and not draft_preview:
+        abort(404)
+
+    payload = request.get_json(silent=True) or {}
+    if not isinstance(payload, dict):
+        return json_error({"code": "Request body must be a JSON object."})
+
+    code = payload.get("code")
+    if not isinstance(code, str):
+        code = ""
+
+    if _discount_attempts_exhausted(event.id) or not discount_code_matches(
+        event,
+        code,
+    ):
+        return jsonify({"valid": False})
+
+    return jsonify(
+        {
+            "valid": True,
+            "options": [
+                {
+                    "id": option.id,
+                    "priceCents": compute_price(option, event, code)[0],
+                }
+                for option in event.price_options
+                if option.active
+            ],
+        }
     )
 
 

--- a/app/static/css/styles/components/_forms.css
+++ b/app/static/css/styles/components/_forms.css
@@ -200,6 +200,48 @@ select.form-input {
   color: #fff;
 }
 
+.price-option__original {
+  display: block;
+  margin-top: 4px;
+  font: 12px var(--font-stack);
+  color: var(--text-faint);
+  text-decoration: line-through;
+}
+
+.price-option-container--selected .price-option__original,
+.price-option-container:has(input[type="radio"]:checked)
+  .price-option__original {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+/* Discount code entry */
+.discount-code-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.discount-code-row .form-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.discount-code-row .btn {
+  flex: 0 0 auto;
+}
+
+.discount-message {
+  display: block;
+  margin-top: 8px;
+  font: 13px/1.5 var(--font-stack);
+  color: var(--text-muted);
+}
+
+/* Matches the error tone used by .card-error. */
+.discount-message--error {
+  color: #e44;
+}
+
 /* Single price summary bar */
 .price-summary {
   background: var(--bg-page);

--- a/app/static/event_registration.js
+++ b/app/static/event_registration.js
@@ -67,6 +67,9 @@
       this.stripePromise = null;
       this.isSubmitting = false;
       this.participantValues = [];
+      // Member prices are never sent to the page up front; they arrive only
+      // after the server verifies a code.
+      this.discountPrices = null;
       this.attachEventListeners();
       this.renderSelectedOption();
     }
@@ -83,6 +86,131 @@
       form.querySelectorAll('input[name="price_option_id"]').forEach(input => {
         input.addEventListener('change', () => this.renderSelectedOption());
       });
+
+      const discountCode = document.getElementById('discount-code');
+      document
+        .getElementById('discount-apply')
+        .addEventListener('click', () => this.applyDiscount());
+      // Enter in the code field should check the code, not submit the form.
+      discountCode.addEventListener('keydown', event => {
+        if (event.key !== 'Enter') return;
+        event.preventDefault();
+        this.applyDiscount();
+      });
+      // A discounted price on screen must never outlive the code that earned
+      // it, or we would show one amount and submit another.
+      discountCode.addEventListener('input', () => {
+        this.setDiscountMessage('');
+        if (!this.discountPrices) return;
+        this.discountPrices = null;
+        this.renderPrices();
+      });
+    }
+
+    priceFor(option) {
+      const discounted =
+        this.discountPrices && this.discountPrices.get(String(option.id));
+      return discounted === undefined || discounted === null
+        ? option.priceCents
+        : discounted;
+    }
+
+    async applyDiscount() {
+      const input = document.getElementById('discount-code');
+      const code = input.value.trim();
+      if (!code) {
+        this.setDiscountMessage('');
+        return;
+      }
+
+      const button = document.getElementById('discount-apply');
+      button.disabled = true;
+      try {
+        const response = await fetch(
+          `/events/${encodeURIComponent(eventData.slug)}/discount`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ code })
+          }
+        );
+        const result = await response.json().catch(() => ({}));
+
+        if (!response.ok || !result.valid) {
+          this.discountPrices = null;
+          this.setDiscountMessage("That code isn't recognized.", true);
+          this.renderPrices();
+          return;
+        }
+
+        this.discountPrices = new Map(
+          (result.options || []).map(option => [
+            String(option.id),
+            option.priceCents
+          ])
+        );
+        this.setDiscountMessage('Member rate applied.');
+        this.renderPrices();
+      } catch (error) {
+        this.discountPrices = null;
+        this.setDiscountMessage(
+          'The code could not be checked. Try again.',
+          true
+        );
+        this.renderPrices();
+      } finally {
+        button.disabled = false;
+      }
+    }
+
+    setDiscountMessage(message, isError = false) {
+      const node = document.getElementById('discount-message');
+      node.textContent = message || '';
+      node.classList.toggle(
+        'discount-message--error',
+        Boolean(message) && isError
+      );
+    }
+
+    // Repaint amounts without rebuilding the participant fields, so typing in
+    // the code box doesn't disturb the rest of the form.
+    renderPrices() {
+      form.querySelectorAll('.price-option-container').forEach(card => {
+        const radio = card.querySelector('input[type="radio"]');
+        const option = optionsById.get(radio.value);
+        if (!option) return;
+
+        const price = this.priceFor(option);
+        card.querySelector('.price-option__amount').textContent =
+          this.formatCurrency(price);
+
+        const original = card.querySelector('.price-option__original');
+        const isDiscounted = price < option.priceCents;
+        original.textContent = isDiscounted
+          ? `Regular ${this.formatCurrency(option.priceCents)}`
+          : '';
+        original.classList.toggle('hidden', !isDiscounted);
+      });
+      this.renderPayButton();
+    }
+
+    renderPayButton() {
+      const option = this.selectedOption;
+      if (!option) return;
+
+      const isFree = this.priceFor(option) === 0;
+      document.getElementById('card-field').classList.toggle('hidden', isFree);
+      document.getElementById('button-text').textContent = isFree
+        ? 'Complete registration'
+        : `Pay ${this.formatCurrency(this.priceFor(option))}`;
+
+      if (!isFree) {
+        this.ensureStripe().catch(() => {
+          this.showError(
+            'The payment form could not be initialized. Refresh and try again.'
+          );
+        });
+      }
     }
 
     snapshotParticipants() {
@@ -121,20 +249,7 @@
       teamName.disabled = !isTeam;
 
       this.applyQuestionScopes(option.name);
-
-      const isFree = option.priceCents === 0;
-      document.getElementById('card-field').classList.toggle('hidden', isFree);
-      document.getElementById('button-text').textContent = isFree
-        ? 'Complete registration'
-        : `Pay ${this.formatCurrency(option.priceCents)}`;
-
-      if (!isFree) {
-        this.ensureStripe().catch(() => {
-          this.showError(
-            'The payment form could not be initialized. Refresh and try again.'
-          );
-        });
-      }
+      this.renderPayButton();
     }
 
     applyQuestionScopes(optionName) {
@@ -304,7 +419,7 @@
       this.toggleLoading(true);
 
       try {
-        if (this.selectedOption.priceCents > 0) {
+        if (this.priceFor(this.selectedOption) > 0) {
           await this.ensureStripe();
         }
 

--- a/app/templates/events/registration.html
+++ b/app/templates/events/registration.html
@@ -61,9 +61,8 @@
                     >
                     <span class="price-option__label">{{ option.name }}</span>
                     <span class="price-option__amount">{{ option.price_cents|format_price }}</span>
-                    {% if option.member_price_cents is not none %}
-                      <span class="form-field__hint" style="display: block; margin-top: 4px;">Member {{ option.member_price_cents|format_price }}</span>
-                    {% endif %}
+                    {# Filled in by the client only once a code is verified. #}
+                    <span class="price-option__original hidden"></span>
                   </label>
                 {% endfor %}
               </div>
@@ -144,7 +143,11 @@
               <p class="form-section__subtitle">The server will verify your option and any discount before charging.</p>
               <div class="form-field">
                 <label class="form-field__label" for="discount-code">Discount code <span class="form-field__hint">(optional)</span></label>
-                <input type="text" id="discount-code" class="form-input" autocomplete="off">
+                <div class="discount-code-row">
+                  <input type="text" id="discount-code" class="form-input" autocomplete="off">
+                  <button type="button" class="btn btn--secondary" id="discount-apply">Apply</button>
+                </div>
+                <span class="discount-message" id="discount-message" role="status" aria-live="polite"></span>
               </div>
               <div id="card-field" class="form-field">
                 <label class="form-field__label" for="card-element">Card details</label>

--- a/tests/events/test_routes.py
+++ b/tests/events/test_routes.py
@@ -472,3 +472,113 @@ def test_post_ignores_a_client_supplied_registration_contact(
     )
     assert registration.contact_email == "participant1@example.com"
     assert registration.contact_phone == "555-0101"
+
+
+def test_get_event_page_withholds_member_pricing(client, public_event):
+    event, _individual, _team, _free = public_event
+
+    page = client.get(f"/events/{event.slug}").get_data(as_text=True)
+
+    # Neither the rendered hint nor the JSON blob may carry the member rate.
+    assert "memberPriceCents" not in page
+    assert "$45.00" not in page
+    assert "$90.00" not in page
+    # The public prices still render, alongside the control that reveals the
+    # member rate.
+    assert "$55.00" in page
+    assert "$105.00" in page
+    assert 'id="discount-apply"' in page
+
+
+def test_discount_check_returns_member_prices_for_a_valid_code(
+    client,
+    public_event,
+):
+    event, individual, team, free = public_event
+
+    response = client.post(
+        f"/events/{event.slug}/discount",
+        json={"code": " tcsc member "},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["valid"] is True
+    prices = {option["id"]: option["priceCents"] for option in body["options"]}
+    assert prices[individual.id] == 4500
+    assert prices[team.id] == 9000
+    # An option with no member rate stays at its public price.
+    assert prices[free.id] == 0
+
+
+def test_discount_check_rejects_an_unknown_code(client, public_event):
+    event, _individual, _team, _free = public_event
+
+    response = client.post(
+        f"/events/{event.slug}/discount",
+        json={"code": "not-the-code"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"valid": False}
+
+
+def test_discount_check_rejects_everything_when_no_code_is_configured(
+    client,
+    db_session,
+    public_event,
+):
+    event, _individual, _team, _free = public_event
+    event.discount_code = None
+    db_session.session.commit()
+
+    for code in ("", "TCSC MEMBER"):
+        response = client.post(
+            f"/events/{event.slug}/discount",
+            json={"code": code},
+        )
+        assert response.get_json() == {"valid": False}
+
+
+def test_discount_check_throttles_repeated_guessing(client, public_event):
+    from app.routes.events import DISCOUNT_ATTEMPT_LIMIT, _discount_attempts
+
+    event, _individual, _team, _free = public_event
+    _discount_attempts.clear()
+
+    for _ in range(DISCOUNT_ATTEMPT_LIMIT):
+        client.post(f"/events/{event.slug}/discount", json={"code": "guess"})
+
+    # A correct code past the limit is refused along with the wrong ones.
+    response = client.post(
+        f"/events/{event.slug}/discount",
+        json={"code": "TCSC MEMBER"},
+    )
+    assert response.get_json() == {"valid": False}
+    _discount_attempts.clear()
+
+
+def test_discount_check_on_draft_is_404_for_anonymous_and_open_for_admin(
+    client,
+    db_session,
+    public_event,
+):
+    event, _individual, _team, _free = public_event
+    event.status = EventStatus.DRAFT
+    db_session.session.commit()
+
+    anonymous = client.post(
+        f"/events/{event.slug}/discount",
+        json={"code": "TCSC MEMBER"},
+    )
+    assert anonymous.status_code == 404
+
+    with client.session_transaction() as session:
+        session["user"] = {"email": "admin@twincitiesskiclub.org"}
+
+    response = client.post(
+        f"/events/{event.slug}/discount",
+        json={"code": "TCSC MEMBER"},
+    )
+    assert response.status_code == 200
+    assert response.get_json()["valid"] is True


### PR DESCRIPTION
## What

On the events page the member price was printed under every registration option, and `memberPriceCents` was also embedded in the page's JSON blob. The member rate is a perk — showing it next to the public price advertises a cheaper price non-members can't have, and tells them exactly what to go looking for.

Now the options render the public price only. The discount code field gets an **Apply** button; a verified code reveals the member rate in place.

## How

- `registration.html` — member price hint removed; code field becomes input + Apply with an inline status line.
- `routes/events.py` — `memberPriceCents` dropped from the page payload; new `POST /events/<slug>/discount` returns `{valid, options:[{id, priceCents}]}`, mirroring the page's draft/404 rules.
- `service.py` — `discount_code_matches()` split out of `compute_price()` so the reveal and the charge share one code check and can't drift.
- `event_registration.js` — Apply flow, strike-through of the regular price, pay-button update. Editing the code after applying reverts the display, so the amount shown can never disagree with the code being submitted.

## Notes

- Field copy stays "Discount code" rather than "Member code" — the page reveals nothing about member pricing existing.
- The endpoint is a yes/no oracle for the code, so it throttles to 10 checks per client per event per 15 minutes. Keyed by client rather than session, since a signed-cookie counter is bypassed by discarding the cookie. It's per-process, so the real ceiling is 10 × worker count.
- Typing a code without clicking Apply still discounts at checkout, unchanged from today.

## Testing

`pytest tests/events/` — 101 passed. Six new/updated cases cover: the page withholding member pricing, valid and unknown codes, an event with no code configured, the throttle, and draft-event access.

Not verified in a browser — the Apply row and strike-through styling are new CSS I've only checked in markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)