### PR TITLE
fix(slack): give Bolt an INFO base logger so event logs emit

### DIFF
--- a/app/slack/bolt_app.py
+++ b/app/slack/bolt_app.py
@@ -24,6 +24,25 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+
+def _build_bolt_base_logger():
+    """Base logger handed to Bolt so listener logs actually emit.
+
+    Gunicorn configures no root handlers and leaves root at WARNING; Bolt
+    copies the base logger's level and handlers onto every listener logger
+    it creates, so without this the INFO event instrumentation never
+    reaches stdout in production.
+    """
+    base = logging.getLogger("tcsc.slack.bolt")
+    base.setLevel(logging.INFO)
+    if not base.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+        )
+        base.addHandler(handler)
+    return base
+
 # Initialize Bolt app with signing secret for request verification
 _bot_token = os.environ.get("SLACK_BOT_TOKEN")
 _app_token = os.environ.get("SLACK_APP_TOKEN")  # For Socket Mode (xapp-...)
@@ -138,7 +157,8 @@ if _bot_token:
         signing_secret=_signing_secret,
         # Process events synchronously before returning response
         # This ensures we're still in Flask's request context
-        process_before_response=True
+        process_before_response=True,
+        logger=_build_bolt_base_logger(),
     )
     handler = SlackRequestHandler(bolt_app)
     logger.info("Slack Bolt app initialized (HTTP mode)")

--- a/tests/slack/test_bolt_logging.py
+++ b/tests/slack/test_bolt_logging.py
@@ -1,0 +1,44 @@
+"""The Bolt base logger must emit INFO to stdout.
+
+Gunicorn configures no root handlers and leaves the root logger at WARNING,
+and slack_bolt copies the base logger's settings onto every listener logger
+it creates. Without an explicit INFO base logger, the event-receipt
+instrumentation (the "slack event received" middleware and the link_shared
+lines) is silently dropped in production.
+"""
+
+import logging
+
+
+def test_bolt_base_logger_enables_info_with_stream_handler():
+    from app.slack.bolt_app import _build_bolt_base_logger
+
+    base = _build_bolt_base_logger()
+    assert base.isEnabledFor(logging.INFO)
+    assert any(isinstance(h, logging.StreamHandler) for h in base.handlers)
+
+
+def test_bolt_base_logger_does_not_stack_handlers():
+    from app.slack.bolt_app import _build_bolt_base_logger
+
+    first = _build_bolt_base_logger()
+    second = _build_bolt_base_logger()
+    assert second is first
+    assert len(second.handlers) == 1
+
+
+def test_listener_logger_inherits_info_from_base():
+    from slack_bolt.logger import get_bolt_app_logger
+
+    from app.slack.bolt_app import _build_bolt_base_logger
+
+    class FakeListener:
+        pass
+
+    listener_logger = get_bolt_app_logger(
+        "test-bolt-logging", FakeListener, _build_bolt_base_logger()
+    )
+    assert listener_logger.isEnabledFor(logging.INFO)
+    assert any(
+        isinstance(h, logging.StreamHandler) for h in listener_logger.handlers
+    )


### PR DESCRIPTION
## Why

Slack re-enabled event delivery for the app tonight (it had been disabled by Slack since Dec 2025; see docs/debug/2026-08-20-link-unfurl-handoff.md for the investigation). Organic link unfurls now work end to end, verified in #testbois.

But the event-receipt instrumentation from #239 never logged anything, even for events that were demonstrably received and handled. Root cause: gunicorn leaves the root logger at WARNING with no handlers, and slack_bolt copies the base logger's level and handlers onto every listener logger it creates, so every `logger.info(...)` in middleware and event handlers was dropped before reaching a handler. (The "Bolt app is running!" banner only appeared because slack_bolt falls back to `print()` when its logger won't emit INFO.)

## What

Pass an explicit base logger (INFO level, stdout StreamHandler) to `App(logger=...)`. Per slack_bolt's documented behavior, that base logger's settings propagate to all bolt-created listener loggers, so `slack event received: <type>`, the link_shared lines, and the global error handler now reach Render logs.

## Tests

- 3 new tests in tests/slack/test_bolt_logging.py (base logger emits INFO via a StreamHandler, no handler stacking on re-init, listener loggers inherit from the base)
- tests/slack + tests/trips: 744 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)